### PR TITLE
cargo: add repository URL

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "raptorq"
 description = "RaptorQ (RFC6330)"
 license = "Apache-2.0"
+repository = "https://github.com/cberner/raptorq"
 version = "0.6.0"
 authors = ["Christopher Berner <christopherberner@gmail.com>"]
 


### PR DESCRIPTION
This adds the repository URL to cargo manifest, so that it will
show up on crates.io.