### PR TITLE
codec: remove some casts and allocations

### DIFF
--- a/benches/matrix_sparsity.rs
+++ b/benches/matrix_sparsity.rs
@@ -25,7 +25,7 @@ fn main() {
             a.height() * a.width()
         );
 
-        let symbols = vec![Symbol::zero(1); a.width()];
+        let symbols = vec![Symbol::zero(1usize); a.width()];
         let mut decoder = IntermediateSymbolDecoder::new(a, symbols, num_symbols);
         decoder.execute();
         println!(

--- a/src/arraymap.rs
+++ b/src/arraymap.rs
@@ -25,13 +25,14 @@ impl<T: std::clone::Clone> ArrayMap<T> {
     }
 
     pub fn keys(&self) -> Vec<usize> {
-        let mut result = Vec::with_capacity(self.elements.len());
-        for i in 0..self.elements.len() {
-            if self.elements[i].is_some() {
-                result.push(i + self.offset);
-            }
-        }
-        return result;
+        self.elements
+            .iter()
+            .enumerate()
+            .filter_map(|(i, elem)| match elem {
+                Some(_) => Some(i + self.offset),
+                None => None,
+            })
+            .collect()
     }
 }
 

--- a/src/base.rs
+++ b/src/base.rs
@@ -217,7 +217,12 @@ impl ObjectTransmissionInformation {
 }
 
 // Partition[I, J] function, as defined in section 4.4.1.2
-pub fn partition(i: u32, j: u32) -> (u32, u32, u32, u32) {
+pub fn partition<TI, TJ>(i: TI, j: TJ) -> (u32, u32, u32, u32)
+where
+    TI: Into<u32>,
+    TJ: Into<u32>,
+{
+    let (i, j) = (i.into(), j.into());
     let il = (i as f64 / j as f64).ceil() as u32;
     let is = (i as f64 / j as f64).floor() as u32;
     let jl = i - is * j;
@@ -260,18 +265,18 @@ pub fn intermediate_tuple(
 
     let B = 10267 * (J + 1);
     let y: u32 = ((B as u64 + internal_symbol_id as u64 * A as u64) % 4294967296) as u32;
-    let v = rand(y, 0, 1048576);
+    let v = rand(y, 0u32, 1048576);
     let d = deg(v, W);
-    let a = 1 + rand(y, 1, W - 1);
-    let b = rand(y, 2, W);
+    let a = 1 + rand(y, 1u32, W - 1);
+    let b = rand(y, 2u32, W);
 
     let mut d1 = 2;
     if d < 4 {
-        d1 = 2 + rand(internal_symbol_id, 3, 2);
+        d1 = 2 + rand(internal_symbol_id, 3u32, 2);
     }
 
-    let a1 = 1 + rand(internal_symbol_id, 4, P1 - 1);
-    let b1 = rand(internal_symbol_id, 5, P1);
+    let a1 = 1 + rand(internal_symbol_id, 4u32, P1 - 1);
+    let b1 = rand(internal_symbol_id, 5u32, P1);
 
     (d, a, b, d1, a1, b1)
 }

--- a/src/constraint_matrix.rs
+++ b/src/constraint_matrix.rs
@@ -31,9 +31,9 @@ fn generate_mt(H: usize, Kprime: usize, S: usize) -> OctetMatrix {
     let mut matrix = OctetMatrix::new(H, Kprime + S);
     for i in 0..H {
         for j in 0..=(Kprime + S - 2) {
-            if i == rand((j + 1) as u32, 6, H as u32) as usize
-                || i == ((rand((j + 1) as u32, 6, H as u32)
-                    + rand((j + 1) as u32, 7, (H - 1) as u32)
+            if i == rand((j + 1) as u32, 6u32, H as u32) as usize
+                || i == ((rand((j + 1) as u32, 6u32, H as u32)
+                    + rand((j + 1) as u32, 7u32, (H - 1) as u32)
                     + 1)
                     % (H as u32)) as usize
             {

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -125,10 +125,13 @@ impl SourceBlockDecoder {
 
         let num_extended_symbols = extended_source_block_symbols(self.source_block_symbols);
         if self.received_source_symbols == self.source_block_symbols {
-            let mut result = vec![];
-            for symbol in self.source_symbols.clone() {
-                result.extend(symbol.unwrap().bytes());
-            }
+            let result = self
+                .source_symbols
+                .iter()
+                .cloned()
+                .map(|symbol| symbol.unwrap().into_bytes())
+                .flatten()
+                .collect();
 
             self.decoded = true;
             return Some(result);
@@ -170,10 +173,10 @@ impl SourceBlockDecoder {
             let mut result = vec![];
             for i in 0..self.source_block_symbols as usize {
                 if let Some(ref symbol) = self.source_symbols[i] {
-                    result.extend(symbol.bytes())
+                    result.extend(symbol.as_bytes())
                 } else {
                     let rebuilt = self.rebuild_source_symbol(&intermediate_symbols, i as u32);
-                    result.extend(rebuilt.bytes());
+                    result.extend(rebuilt.as_bytes());
                 }
             }
 

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -27,11 +27,11 @@ impl Encoder {
         );
 
         let kt = (config.transfer_length() as f64 / config.symbol_size() as f64).ceil() as u32;
-        let (kl, ks, zl, zs) = partition(kt, config.source_blocks() as u32);
+        let (kl, ks, zl, zs) = partition(kt, config.source_blocks());
 
         // TODO: support subblocks
         assert_eq!(1, config.sub_blocks());
-        //        let (tl, ts, nl, ns) = partition((config.symbol_size() / config.alignment() as u16) as u32, config.sub_blocks() as u32);
+        //        let (tl, ts, nl, ns) = partition((config.symbol_size() / config.alignment() as u16) as u32, config.sub_blocks());
 
         let mut data_index = 0;
         let mut blocks = vec![];

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -121,7 +121,7 @@ impl SourceBlockEncoder {
                 esi += 1;
                 EncodingPacket::new(
                     PayloadId::new(self.source_block_id, esi as u32),
-                    symbol.bytes().clone(),
+                    symbol.as_bytes().to_vec(),
                 )
             })
             .collect()
@@ -144,8 +144,7 @@ impl SourceBlockEncoder {
                     &self.intermediate_symbols,
                     tuple,
                 )
-                .bytes()
-                .clone(),
+                .into_bytes(),
             ));
         }
         result

--- a/src/pi_solver.rs
+++ b/src/pi_solver.rs
@@ -905,7 +905,7 @@ mod tests {
             let num_symbols = extended_source_block_symbols(elements);
             let indices: Vec<u32> = (0..num_symbols).collect();
             let a = generate_constraint_matrix(num_symbols, &indices);
-            let symbols = vec![Symbol::zero(1); a.width()];
+            let symbols = vec![Symbol::zero(1usize); a.width()];
             let mut decoder = IntermediateSymbolDecoder::new(a, symbols, num_symbols);
             decoder.execute();
             assert!(

--- a/src/rng.rs
+++ b/src/rng.rs
@@ -223,12 +223,16 @@ const V3: [u32; 256] = [
     3432275192];
 
 // As defined in section 5.3.5.1
-pub fn rand(y: u32, i: u8, m: u32) -> u32 {
+pub fn rand<TI>(y: u32, i: TI, m: u32) -> u32
+where
+    TI: Into<u32>,
+{
     assert!(m > 0);
-    let x0 = (y + i as u32) % 256;
-    let x1 = ((y >> 8) + i as u32) % 256;
-    let x2 = ((y >> 16) + i as u32) % 256;
-    let x3 = ((y >> 24) + i as u32) % 256;
+    let i = i.into();
+    let x0 = (y + i) % 256;
+    let x1 = ((y >> 8) + i) % 256;
+    let x2 = ((y >> 16) + i) % 256;
+    let x3 = ((y >> 24) + i) % 256;
 
     (V0[x0 as usize] ^ V1[x1 as usize] ^ V2[x2 as usize] ^ V3[x3 as usize]) % m
 }

--- a/src/symbol.rs
+++ b/src/symbol.rs
@@ -4,6 +4,7 @@ use crate::octets::fused_addassign_mul_scalar;
 use crate::octets::mulassign_scalar;
 use std::ops::AddAssign;
 
+/// Elementary unit of data, for encoding/decoding purposes.
 #[derive(Clone, Debug, PartialEq)]
 pub struct Symbol {
     value: Vec<u8>,
@@ -14,6 +15,7 @@ impl Symbol {
         Symbol { value }
     }
 
+    /// Initialize a zeroed symbol, with given size.
     pub fn zero<T>(size: T) -> Symbol
     where
         T: Into<usize>,
@@ -28,8 +30,14 @@ impl Symbol {
         self.value.len()
     }
 
-    pub fn bytes(&self) -> &Vec<u8> {
+    /// Return the underlying byte slice for a symbol.
+    pub fn as_bytes(&self) -> &[u8] {
         &self.value
+    }
+
+    /// Consume a symbol into a vector of bytes.
+    pub fn into_bytes(self) -> Vec<u8> {
+        self.value
     }
 
     pub fn mulassign_scalar(&mut self, scalar: &Octet) {
@@ -68,6 +76,6 @@ mod tests {
         let symbol2 = Symbol::new(data2);
 
         symbol1 += &symbol2;
-        assert_eq!(result, *symbol1.bytes());
+        assert_eq!(result, symbol1.into_bytes());
     }
 }

--- a/src/symbol.rs
+++ b/src/symbol.rs
@@ -14,9 +14,12 @@ impl Symbol {
         Symbol { value }
     }
 
-    pub fn zero(size: usize) -> Symbol {
+    pub fn zero<T>(size: T) -> Symbol
+    where
+        T: Into<usize>,
+    {
         Symbol {
-            value: vec![0; size],
+            value: vec![0; size.into()],
         }
     }
 


### PR DESCRIPTION
This performs a cleanup on encoder and decoder, to remove some redundant casts and bytes duplications.