### PR TITLE
Breaking up the decoding method in smaller single-purpose methods

### DIFF
--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -77,6 +77,28 @@ impl Decoder {
         result.truncate(self.config.transfer_length() as usize);
         Some(result)
     }
+
+    pub fn add_new_packet(&mut self, packet: EncodingPacket) {
+        let block_number = packet.payload_id.source_block_number() as usize;
+        if self.blocks[block_number].is_none() {
+            self.blocks[block_number] = self.block_decoders[block_number].decode(vec![packet]);
+        }
+    }
+
+    pub fn get_result(&self) -> Option<Vec<u8>> {
+        for block in self.blocks.iter() {
+            if block.is_none() {
+                return None;
+            }
+        }
+
+        let mut result = vec![];
+        for block in self.blocks.iter() {
+            result.extend(block.clone().unwrap());
+        }
+        result.truncate(self.config.transfer_length() as usize);
+        Some(result)
+    }
 }
 
 pub struct SourceBlockDecoder {


### PR DESCRIPTION
Hi,

First I'd like to say thank you for this amazing library ! I've been looking for a functional and fast fountain code library in Rust for a while. 

I've noticed a specific need I have in my use of your library: I process packets and get the resulting data in separate places. The use of the `decode` method on the `Decoder` object is impractical to me. I therefore divided it in two separate methods: one that mutates the Decoder by adding a new packet and one that just 'checks' if decoding is possible yet.

I hope it makes some sense.