### PR TITLE
Fix generation of constraint matrix for 1698 and 8837 source symbols

### DIFF
--- a/src/octet.rs
+++ b/src/octet.rs
@@ -1212,9 +1212,10 @@ impl Octet {
         Octet { value: 1 }
     }
 
-    pub fn alpha(i: u8) -> Octet {
+    pub fn alpha(i: usize) -> Octet {
+        assert!(i < 256);
         Octet {
-            value: OCT_EXP[i as usize],
+            value: OCT_EXP[i],
         }
     }
 


### PR DESCRIPTION
The gamma matrix was being generated incorrectly due to casting
(i - j) to u8 instead of wrapping it to 255 values