### PR TITLE
feat: Derived serde::{Serialize, Deserialize} on all public types.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,9 @@ version = "1.0.0"
 edition = "2018"
 authors = ["Christopher Berner <christopherberner@gmail.com>"]
 
+[dependencies]
+serde = {version = "1.0.102", features=["std", "derive"]}
+
 [dev-dependencies]
 criterion = "0.3"
 primal = "0.2"

--- a/src/arraymap.rs
+++ b/src/arraymap.rs
@@ -1,4 +1,6 @@
-#[derive(Clone)]
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, PartialOrd, Eq, Ord, Hash)]
 pub struct ArrayMap<T> {
     offset: usize,
     elements: Vec<Option<T>>,
@@ -50,7 +52,7 @@ impl<T: std::clone::Clone> ArrayMap<T> {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, PartialOrd, Eq, Ord, Hash)]
 pub struct UsizeArrayMap {
     offset: usize,
     elements: Vec<usize>,
@@ -85,7 +87,7 @@ impl UsizeArrayMap {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, PartialOrd, Eq, Ord, Hash)]
 pub struct BoolArrayMap {
     offset: usize,
     elements: Vec<bool>,

--- a/src/base.rs
+++ b/src/base.rs
@@ -1,10 +1,10 @@
-use std::cmp::min;
-
 use crate::rng::rand;
 use crate::systematic_constants::SYSTEMATIC_INDICES_AND_PARAMETERS;
+use serde::{Deserialize, Serialize};
+use std::cmp::min;
 
 // As defined in section 3.2
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, PartialOrd, Eq, Ord, Hash)]
 pub struct PayloadId {
     source_block_number: u8,
     encoding_symbol_id: u32,
@@ -49,7 +49,7 @@ impl PayloadId {
 /// Contains encoding symbols generated from a source block.
 ///
 /// As defined in section [4.4.2](https://tools.ietf.org/html/rfc6330#section-4.4.2).
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, PartialOrd, Eq, Ord, Serialize, Deserialize, Hash)]
 pub struct EncodingPacket {
     pub(crate) payload_id: PayloadId,
     pub(crate) data: Vec<u8>,
@@ -92,7 +92,7 @@ impl EncodingPacket {
 }
 
 // As defined in section 3.3.2 and 3.3.3
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, PartialOrd, Eq, Ord, Serialize, Deserialize, Hash)]
 pub struct ObjectTransmissionInformation {
     transfer_length: u64, // Limited to u40
     symbol_size: u16,

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -14,8 +14,10 @@ use crate::systematic_constants::num_ldpc_symbols;
 use crate::systematic_constants::{
     calculate_p1, extended_source_block_symbols, num_lt_symbols, num_pi_symbols, systematic_index,
 };
+use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
 
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct Decoder {
     config: ObjectTransmissionInformation,
     block_decoders: Vec<SourceBlockDecoder>,
@@ -104,6 +106,7 @@ impl Decoder {
     }
 }
 
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct SourceBlockDecoder {
     source_block_id: u8,
     symbol_size: u16,

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -15,9 +15,11 @@ use crate::systematic_constants::num_lt_symbols;
 use crate::systematic_constants::num_pi_symbols;
 use crate::systematic_constants::{calculate_p1, systematic_index};
 use crate::ObjectTransmissionInformation;
+use serde::{Deserialize, Serialize};
 
 pub const SPARSE_MATRIX_THRESHOLD: u32 = 250;
 
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct Encoder {
     config: ObjectTransmissionInformation,
     blocks: Vec<SourceBlockEncoder>,
@@ -96,6 +98,7 @@ impl Encoder {
     }
 }
 
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct SourceBlockEncoder {
     source_block_id: u8,
     source_symbols: Vec<Symbol>,

--- a/src/iterators.rs
+++ b/src/iterators.rs
@@ -1,6 +1,8 @@
 use crate::octet::Octet;
 use crate::sparse_vec::{SparseOctetVec, SparseValuelessVec};
+use serde::{Deserialize, Serialize};
 
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, PartialOrd, Eq, Ord, Hash)]
 pub struct KeyIter {
     sparse: bool,
     dense_index: usize,
@@ -24,6 +26,7 @@ impl Iterator for KeyIter {
     }
 }
 
+#[derive(Clone, Debug, PartialEq, PartialOrd, Eq, Ord, Hash)]
 pub struct BorrowedKeyIter<'a> {
     sparse: bool,
     dense_index: usize,
@@ -131,6 +134,7 @@ impl<'a> Iterator for BorrowedKeyIter<'a> {
     }
 }
 
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, PartialOrd, Eq, Ord, Hash)]
 pub struct ClonedOctetIter {
     sparse: bool,
     end_col: usize,
@@ -166,6 +170,7 @@ impl Iterator for ClonedOctetIter {
     }
 }
 
+#[derive(Clone, Debug, PartialEq, PartialOrd, Eq, Ord, Hash)]
 pub struct OctetIter<'a> {
     sparse: bool,
     start_col: usize,

--- a/src/matrix.rs
+++ b/src/matrix.rs
@@ -3,6 +3,7 @@ use crate::octet::Octet;
 use crate::octets::fused_addassign_mul_scalar;
 use crate::octets::{add_assign, count_ones_and_nonzeros, mulassign_scalar};
 use crate::util::get_both_indices;
+use serde::{Deserialize, Serialize};
 
 pub trait OctetMatrix: Clone {
     fn new(
@@ -62,7 +63,7 @@ pub trait OctetMatrix: Clone {
     fn resize(&mut self, new_height: usize, new_width: usize);
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, PartialOrd, Eq, Ord, Serialize, Deserialize, Hash)]
 pub struct DenseOctetMatrix {
     height: usize,
     width: usize,

--- a/src/octet.rs
+++ b/src/octet.rs
@@ -1,3 +1,4 @@
+use serde::{Deserialize, Serialize};
 use std::ops::Add;
 use std::ops::AddAssign;
 use std::ops::Div;
@@ -1194,7 +1195,7 @@ const fn calculate_octet_mul_table_inner(x: usize) -> [u8; 256] {
     ];
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, PartialOrd, Eq, Ord, Hash)]
 pub struct Octet {
     value: u8,
 }

--- a/src/pi_solver.rs
+++ b/src/pi_solver.rs
@@ -8,7 +8,9 @@ use crate::systematic_constants::num_intermediate_symbols;
 use crate::systematic_constants::num_ldpc_symbols;
 use crate::systematic_constants::num_pi_symbols;
 use crate::util::get_both_indices;
+use serde::{Deserialize, Serialize};
 
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, PartialOrd, Eq, Ord, Hash)]
 struct FirstPhaseRowSelectionStats {
     original_degree: UsizeArrayMap,
     non_zeros_per_row: UsizeArrayMap,
@@ -379,6 +381,7 @@ impl FirstPhaseRowSelectionStats {
 
 // See section 5.4.2.1
 #[allow(non_snake_case)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, PartialOrd, Eq, Ord, Hash)]
 pub struct IntermediateSymbolDecoder<T: OctetMatrix> {
     A: T,
     X: T,

--- a/src/sparse_matrix.rs
+++ b/src/sparse_matrix.rs
@@ -5,6 +5,7 @@ use crate::octets::{add_assign, mulassign_scalar};
 use crate::octets::{count_ones_and_nonzeros, fused_addassign_mul_scalar};
 use crate::sparse_vec::{SparseOctetVec, SparseValuelessVec};
 use crate::util::get_both_indices;
+use serde::{Deserialize, Serialize};
 use std::cmp::min;
 
 // Stores a matrix in sparse representation, with an optional dense block for the right most columns,
@@ -21,7 +22,7 @@ use std::cmp::min;
 // |--------------------------|
 // |  (optional) dense rows   |
 // |--------------------------|
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, PartialOrd, Eq, Ord, Serialize, Deserialize, Hash)]
 pub struct SparseOctetMatrix {
     height: usize,
     width: usize,

--- a/src/sparse_vec.rs
+++ b/src/sparse_vec.rs
@@ -1,7 +1,8 @@
 use crate::octet::Octet;
+use serde::{Deserialize, Serialize};
 use std::cmp::Ordering;
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, PartialOrd, Eq, Ord, Serialize, Deserialize, Hash)]
 pub struct SparseOctetVec {
     // Kept sorted by the usize (key)
     elements: Vec<(usize, Octet)>,
@@ -143,7 +144,7 @@ impl SparseOctetVec {
     }
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, PartialOrd, Eq, Ord, Serialize, Deserialize, Hash)]
 pub struct SparseValuelessVec {
     // Kept sorted
     elements: Vec<usize>,

--- a/src/symbol.rs
+++ b/src/symbol.rs
@@ -2,10 +2,11 @@ use crate::octet::Octet;
 use crate::octets::add_assign;
 use crate::octets::fused_addassign_mul_scalar;
 use crate::octets::mulassign_scalar;
+use serde::{Deserialize, Serialize};
 use std::ops::AddAssign;
 
 /// Elementary unit of data, for encoding/decoding purposes.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, PartialOrd, Eq, Ord, Serialize, Deserialize, Hash)]
 pub struct Symbol {
     value: Vec<u8>,
 }


### PR DESCRIPTION
This should make it possible to use serde to serialize and deserialize
encoders/decoders while they are in use.  This is makes it possible to
ship them between processes as needed.