### PR TITLE
Update benchmarks with 1.1.0 results

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,39 +20,39 @@ The following were run on an Intel Core i5-6600K @ 3.50GHz
 
 ```
 Symbol size: 1280 bytes
-symbol count = 10, encoded 127 MB in 0.494secs, throughput: 2072.7Mbit/s
-symbol count = 100, encoded 127 MB in 0.554secs, throughput: 1847.4Mbit/s
-symbol count = 250, encoded 127 MB in 0.859secs, throughput: 1190.9Mbit/s
-symbol count = 500, encoded 127 MB in 0.841secs, throughput: 1213.4Mbit/s
-symbol count = 1000, encoded 126 MB in 0.949secs, throughput: 1070.2Mbit/s
-symbol count = 2000, encoded 126 MB in 1.119secs, throughput: 907.6Mbit/s
-symbol count = 5000, encoded 122 MB in 1.327secs, throughput: 735.9Mbit/s
-symbol count = 10000, encoded 122 MB in 1.749secs, throughput: 558.4Mbit/s
-symbol count = 20000, encoded 122 MB in 2.784secs, throughput: 350.8Mbit/s
-symbol count = 50000, encoded 122 MB in 4.381secs, throughput: 222.9Mbit/s
+symbol count = 10, encoded 127 MB in 0.537secs, throughput: 1906.8Mbit/s
+symbol count = 100, encoded 127 MB in 0.590secs, throughput: 1734.6Mbit/s
+symbol count = 250, encoded 127 MB in 0.572secs, throughput: 1788.4Mbit/s
+symbol count = 500, encoded 127 MB in 0.554secs, throughput: 1842.1Mbit/s
+symbol count = 1000, encoded 126 MB in 0.583secs, throughput: 1742.1Mbit/s
+symbol count = 2000, encoded 126 MB in 0.657secs, throughput: 1545.9Mbit/s
+symbol count = 5000, encoded 122 MB in 0.725secs, throughput: 1347.0Mbit/s
+symbol count = 10000, encoded 122 MB in 0.915secs, throughput: 1067.3Mbit/s
+symbol count = 20000, encoded 122 MB in 1.335secs, throughput: 731.5Mbit/s
+symbol count = 50000, encoded 122 MB in 1.990secs, throughput: 490.7Mbit/s
 
 Symbol size: 1280 bytes
-symbol count = 10, decoded 127 MB in 0.687secs using 0.0% overhead, throughput: 1490.4Mbit/s
-symbol count = 100, decoded 127 MB in 0.705secs using 0.0% overhead, throughput: 1451.7Mbit/s
-symbol count = 250, decoded 127 MB in 0.928secs using 0.0% overhead, throughput: 1102.3Mbit/s
-symbol count = 500, decoded 127 MB in 0.969secs using 0.0% overhead, throughput: 1053.2Mbit/s
-symbol count = 1000, decoded 126 MB in 1.108secs using 0.0% overhead, throughput: 916.6Mbit/s
-symbol count = 2000, decoded 126 MB in 1.286secs using 0.0% overhead, throughput: 789.8Mbit/s
-symbol count = 5000, decoded 122 MB in 1.601secs using 0.0% overhead, throughput: 610.0Mbit/s
-symbol count = 10000, decoded 122 MB in 2.169secs using 0.0% overhead, throughput: 450.2Mbit/s
-symbol count = 20000, decoded 122 MB in 2.945secs using 0.0% overhead, throughput: 331.6Mbit/s
-symbol count = 50000, decoded 122 MB in 5.602secs using 0.0% overhead, throughput: 174.3Mbit/s
+symbol count = 10, decoded 127 MB in 0.728secs using 0.0% overhead, throughput: 1406.5Mbit/s
+symbol count = 100, decoded 127 MB in 0.699secs using 0.0% overhead, throughput: 1464.1Mbit/s
+symbol count = 250, decoded 127 MB in 0.639secs using 0.0% overhead, throughput: 1600.9Mbit/s
+symbol count = 500, decoded 127 MB in 0.643secs using 0.0% overhead, throughput: 1587.1Mbit/s
+symbol count = 1000, decoded 126 MB in 0.674secs using 0.0% overhead, throughput: 1506.9Mbit/s
+symbol count = 2000, decoded 126 MB in 0.749secs using 0.0% overhead, throughput: 1356.0Mbit/s
+symbol count = 5000, decoded 122 MB in 0.877secs using 0.0% overhead, throughput: 1113.5Mbit/s
+symbol count = 10000, decoded 122 MB in 1.182secs using 0.0% overhead, throughput: 826.2Mbit/s
+symbol count = 20000, decoded 122 MB in 1.528secs using 0.0% overhead, throughput: 639.1Mbit/s
+symbol count = 50000, decoded 122 MB in 2.596secs using 0.0% overhead, throughput: 376.2Mbit/s
 
-symbol count = 10, decoded 127 MB in 0.684secs using 5.0% overhead, throughput: 1497.0Mbit/s
-symbol count = 100, decoded 127 MB in 0.704secs using 5.0% overhead, throughput: 1453.7Mbit/s
-symbol count = 250, decoded 127 MB in 0.906secs using 5.0% overhead, throughput: 1129.1Mbit/s
-symbol count = 500, decoded 127 MB in 0.920secs using 5.0% overhead, throughput: 1109.2Mbit/s
-symbol count = 1000, decoded 126 MB in 1.108secs using 5.0% overhead, throughput: 916.6Mbit/s
-symbol count = 2000, decoded 126 MB in 1.275secs using 5.0% overhead, throughput: 796.6Mbit/s
-symbol count = 5000, decoded 122 MB in 1.508secs using 5.0% overhead, throughput: 647.6Mbit/s
-symbol count = 10000, decoded 122 MB in 2.006secs using 5.0% overhead, throughput: 486.8Mbit/s
-symbol count = 20000, decoded 122 MB in 2.729secs using 5.0% overhead, throughput: 357.8Mbit/s
-symbol count = 50000, decoded 122 MB in 4.498secs using 5.0% overhead, throughput: 217.1Mbit/s
+symbol count = 10, decoded 127 MB in 0.725secs using 5.0% overhead, throughput: 1412.3Mbit/s
+symbol count = 100, decoded 127 MB in 0.702secs using 5.0% overhead, throughput: 1457.9Mbit/s
+symbol count = 250, decoded 127 MB in 0.626secs using 5.0% overhead, throughput: 1634.1Mbit/s
+symbol count = 500, decoded 127 MB in 0.620secs using 5.0% overhead, throughput: 1646.0Mbit/s
+symbol count = 1000, decoded 126 MB in 0.634secs using 5.0% overhead, throughput: 1601.9Mbit/s
+symbol count = 2000, decoded 126 MB in 0.685secs using 5.0% overhead, throughput: 1482.7Mbit/s
+symbol count = 5000, decoded 122 MB in 0.830secs using 5.0% overhead, throughput: 1176.6Mbit/s
+symbol count = 10000, decoded 122 MB in 1.059secs using 5.0% overhead, throughput: 922.2Mbit/s
+symbol count = 20000, decoded 122 MB in 1.370secs using 5.0% overhead, throughput: 712.8Mbit/s
+symbol count = 50000, decoded 122 MB in 2.348secs using 5.0% overhead, throughput: 415.9Mbit/s
 ```
 
 ### Public API


### PR DESCRIPTION
Approximately 1.5x faster for symbol counts over 250, and 2x faster over
5k symbols