### PR TITLE
Changes for my use case

### DIFF
--- a/src/base.rs
+++ b/src/base.rs
@@ -97,7 +97,7 @@ impl EncodingPacket {
 }
 
 // As defined in section 3.3.2 and 3.3.3
-#[derive(Clone, Debug, PartialEq, PartialOrd, Eq, Ord, Hash)]
+#[derive(Copy, Clone, Debug, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde_support", derive(Serialize, Deserialize))]
 pub struct ObjectTransmissionInformation {
     transfer_length: u64, // Limited to u40

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -99,7 +99,7 @@ pub struct Encoder {
 }
 
 impl Encoder {
-    fn new(data: &[u8], config: ObjectTransmissionInformation) -> Encoder {
+    pub fn new(data: &[u8], config: ObjectTransmissionInformation) -> Encoder {
         let mut block_encoders = vec![];
         let mut cached_plan: Option<SourceBlockEncodingPlan> = None;
         for (i, (start, end)) in calculate_block_offsets(data, &config).drain(..).enumerate() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,7 @@ mod symbol;
 mod systematic_constants;
 mod util;
 
+pub use crate::base::partition;
 pub use crate::base::EncodingPacket;
 pub use crate::base::ObjectTransmissionInformation;
 pub use crate::base::PayloadId;


### PR DESCRIPTION
Hi!

I now have a copy of the decoder implementation in my code with my additional get partial result function. For that to work i need to have access to the partition function or copy it as-well. I felt like it really belonged in the raptorq crate so in this pr i make it public.

I'm using the encoder from a c++ application through an ffi interface. I'm doing it in two phases where i first want to know the ObjectTransmissionInformation before i can calculate how many extra packets i want to generate. To make this easier i make the new method of OTI public and made the struct copy.

All of these changes are maybe not aligned with your vision for the reptorq crate and that is perfectly ok! I'm presenting them to you to see it you want them. If there is any subset that you want i can change the pr to only include the changes that you want to have! Otherwise just feel free to close this!

Cheers!

Jonathan
