### PR TITLE
Avoid bounds checking in loop

### DIFF
--- a/src/gf2.rs
+++ b/src/gf2.rs
@@ -1,6 +1,7 @@
 pub fn add_assign_binary(dest: &mut [u64], src: &[u64]) {
-    for i in 0..dest.len() {
+    let len = dest.len();
+    for (dest, &src) in dest.iter_mut().zip(&src[..len]) {
         // Addition over GF(2) is defined as XOR
-        dest[i] ^= src[i];
+        *dest ^= src;
     }
 }


### PR DESCRIPTION
Old version of code used single index to index both `dest` and `src`. Since in general the length of `src` is not known beforehand to be less or equal to length of `dest`, the compiler had no other choice but to keep bounds checking related code. Moreover, since panic information includes information about index, the code has to process one `u32` per iteration.

Checking the length of `src` _before_ starting the loop lets the optimizer eliminate bounds checking and vectorise the loop, ultimately leading to better (at least, I hope so) performance.

[Assembly before and after the change](https://godbolt.org/z/fs4f33)