### PR TITLE
Optimize memory layout of dense U matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,51 +23,51 @@ The following were run on an Intel Core i5-6600K @ 3.50GHz
 
 ```
 Symbol size: 1280 bytes (without pre-built plan)
-symbol count = 10, encoded 127 MB in 0.545secs, throughput: 1878.8Mbit/s
-symbol count = 100, encoded 127 MB in 0.645secs, throughput: 1586.7Mbit/s
-symbol count = 250, encoded 127 MB in 0.509secs, throughput: 2009.7Mbit/s
-symbol count = 500, encoded 127 MB in 0.503secs, throughput: 2028.8Mbit/s
-symbol count = 1000, encoded 126 MB in 0.544secs, throughput: 1867.0Mbit/s
-symbol count = 2000, encoded 126 MB in 0.628secs, throughput: 1617.2Mbit/s
-symbol count = 5000, encoded 122 MB in 0.686secs, throughput: 1423.6Mbit/s
-symbol count = 10000, encoded 122 MB in 0.833secs, throughput: 1172.3Mbit/s
-symbol count = 20000, encoded 122 MB in 1.234secs, throughput: 791.4Mbit/s
-symbol count = 50000, encoded 122 MB in 1.786secs, throughput: 546.8Mbit/s
+symbol count = 10, encoded 127 MB in 0.548secs, throughput: 1868.5Mbit/s
+symbol count = 100, encoded 127 MB in 0.637secs, throughput: 1606.7Mbit/s
+symbol count = 250, encoded 127 MB in 0.507secs, throughput: 2017.7Mbit/s
+symbol count = 500, encoded 127 MB in 0.488secs, throughput: 2091.2Mbit/s
+symbol count = 1000, encoded 126 MB in 0.523secs, throughput: 1941.9Mbit/s
+symbol count = 2000, encoded 126 MB in 0.599secs, throughput: 1695.5Mbit/s
+symbol count = 5000, encoded 122 MB in 0.636secs, throughput: 1535.5Mbit/s
+symbol count = 10000, encoded 122 MB in 0.769secs, throughput: 1269.9Mbit/s
+symbol count = 20000, encoded 122 MB in 1.122secs, throughput: 870.4Mbit/s
+symbol count = 50000, encoded 122 MB in 1.597secs, throughput: 611.5Mbit/s
 
 Symbol size: 1280 bytes (with pre-built plan)
 symbol count = 10, encoded 127 MB in 0.221secs, throughput: 4633.1Mbit/s
-symbol count = 100, encoded 127 MB in 0.149secs, throughput: 6868.7Mbit/s
-symbol count = 250, encoded 127 MB in 0.164secs, throughput: 6237.5Mbit/s
-symbol count = 500, encoded 127 MB in 0.169secs, throughput: 6038.5Mbit/s
-symbol count = 1000, encoded 126 MB in 0.178secs, throughput: 5705.8Mbit/s
-symbol count = 2000, encoded 126 MB in 0.214secs, throughput: 4745.9Mbit/s
-symbol count = 5000, encoded 122 MB in 0.262secs, throughput: 3727.3Mbit/s
-symbol count = 10000, encoded 122 MB in 0.344secs, throughput: 2838.8Mbit/s
-symbol count = 20000, encoded 122 MB in 0.427secs, throughput: 2287.0Mbit/s
-symbol count = 50000, encoded 122 MB in 0.541secs, throughput: 1805.1Mbit/s
+symbol count = 100, encoded 127 MB in 0.154secs, throughput: 6645.7Mbit/s
+symbol count = 250, encoded 127 MB in 0.160secs, throughput: 6393.4Mbit/s
+symbol count = 500, encoded 127 MB in 0.163secs, throughput: 6260.8Mbit/s
+symbol count = 1000, encoded 126 MB in 0.173secs, throughput: 5870.7Mbit/s
+symbol count = 2000, encoded 126 MB in 0.199secs, throughput: 5103.6Mbit/s
+symbol count = 5000, encoded 122 MB in 0.255secs, throughput: 3829.7Mbit/s
+symbol count = 10000, encoded 122 MB in 0.339secs, throughput: 2880.7Mbit/s
+symbol count = 20000, encoded 122 MB in 0.425secs, throughput: 2297.8Mbit/s
+symbol count = 50000, encoded 122 MB in 0.536secs, throughput: 1821.9Mbit/s
 
 Symbol size: 1280 bytes
-symbol count = 10, decoded 127 MB in 0.749secs using 0.0% overhead, throughput: 1367.1Mbit/s
-symbol count = 100, decoded 127 MB in 0.742secs using 0.0% overhead, throughput: 1379.3Mbit/s
-symbol count = 250, decoded 127 MB in 0.589secs using 0.0% overhead, throughput: 1736.8Mbit/s
-symbol count = 500, decoded 127 MB in 0.594secs using 0.0% overhead, throughput: 1718.0Mbit/s
-symbol count = 1000, decoded 126 MB in 0.638secs using 0.0% overhead, throughput: 1591.9Mbit/s
-symbol count = 2000, decoded 126 MB in 0.718secs using 0.0% overhead, throughput: 1414.5Mbit/s
-symbol count = 5000, decoded 122 MB in 0.829secs using 0.0% overhead, throughput: 1178.0Mbit/s
-symbol count = 10000, decoded 122 MB in 1.049secs using 0.0% overhead, throughput: 930.9Mbit/s
-symbol count = 20000, decoded 122 MB in 1.382secs using 0.0% overhead, throughput: 706.6Mbit/s
-symbol count = 50000, decoded 122 MB in 2.355secs using 0.0% overhead, throughput: 414.7Mbit/s
+symbol count = 10, decoded 127 MB in 0.758secs using 0.0% overhead, throughput: 1350.8Mbit/s
+symbol count = 100, decoded 127 MB in 0.740secs using 0.0% overhead, throughput: 1383.0Mbit/s
+symbol count = 250, decoded 127 MB in 0.577secs using 0.0% overhead, throughput: 1772.9Mbit/s
+symbol count = 500, decoded 127 MB in 0.582secs using 0.0% overhead, throughput: 1753.4Mbit/s
+symbol count = 1000, decoded 126 MB in 0.628secs using 0.0% overhead, throughput: 1617.2Mbit/s
+symbol count = 2000, decoded 126 MB in 0.684secs using 0.0% overhead, throughput: 1484.8Mbit/s
+symbol count = 5000, decoded 122 MB in 0.785secs using 0.0% overhead, throughput: 1244.0Mbit/s
+symbol count = 10000, decoded 122 MB in 0.965secs using 0.0% overhead, throughput: 1012.0Mbit/s
+symbol count = 20000, decoded 122 MB in 1.345secs using 0.0% overhead, throughput: 726.1Mbit/s
+symbol count = 50000, decoded 122 MB in 2.101secs using 0.0% overhead, throughput: 464.8Mbit/s
 
-symbol count = 10, decoded 127 MB in 0.740secs using 5.0% overhead, throughput: 1383.7Mbit/s
-symbol count = 100, decoded 127 MB in 0.747secs using 5.0% overhead, throughput: 1370.1Mbit/s
-symbol count = 250, decoded 127 MB in 0.581secs using 5.0% overhead, throughput: 1760.7Mbit/s
-symbol count = 500, decoded 127 MB in 0.565secs using 5.0% overhead, throughput: 1806.2Mbit/s
-symbol count = 1000, decoded 126 MB in 0.605secs using 5.0% overhead, throughput: 1678.7Mbit/s
-symbol count = 2000, decoded 126 MB in 0.656secs using 5.0% overhead, throughput: 1548.2Mbit/s
-symbol count = 5000, decoded 122 MB in 0.763secs using 5.0% overhead, throughput: 1279.9Mbit/s
-symbol count = 10000, decoded 122 MB in 0.959secs using 5.0% overhead, throughput: 1018.3Mbit/s
-symbol count = 20000, decoded 122 MB in 1.242secs using 5.0% overhead, throughput: 786.3Mbit/s
-symbol count = 50000, decoded 122 MB in 2.146secs using 5.0% overhead, throughput: 455.1Mbit/s
+symbol count = 10, decoded 127 MB in 0.753secs using 5.0% overhead, throughput: 1359.8Mbit/s
+symbol count = 100, decoded 127 MB in 0.731secs using 5.0% overhead, throughput: 1400.1Mbit/s
+symbol count = 250, decoded 127 MB in 0.575secs using 5.0% overhead, throughput: 1779.0Mbit/s
+symbol count = 500, decoded 127 MB in 0.552secs using 5.0% overhead, throughput: 1848.7Mbit/s
+symbol count = 1000, decoded 126 MB in 0.568secs using 5.0% overhead, throughput: 1788.1Mbit/s
+symbol count = 2000, decoded 126 MB in 0.626secs using 5.0% overhead, throughput: 1622.4Mbit/s
+symbol count = 5000, decoded 122 MB in 0.713secs using 5.0% overhead, throughput: 1369.7Mbit/s
+symbol count = 10000, decoded 122 MB in 0.893secs using 5.0% overhead, throughput: 1093.6Mbit/s
+symbol count = 20000, decoded 122 MB in 1.147secs using 5.0% overhead, throughput: 851.4Mbit/s
+symbol count = 50000, decoded 122 MB in 1.943secs using 5.0% overhead, throughput: 502.6Mbit/s
 ```
 
 ### Public API

--- a/src/pi_solver.rs
+++ b/src/pi_solver.rs
@@ -812,16 +812,12 @@ impl<T: BinaryMatrix> IntermediateSymbolDecoder<T> {
     #[inline(never)]
     fn fourth_phase(&mut self) {
         for i in 0..self.i {
-            for j in 0..self.u {
-                let b = self.A.get(i, j + self.i);
-                if b != Octet::zero() {
-                    let temp = self.i;
-                    #[cfg(debug_assertions)]
-                    self.fma_rows(temp + j, i, b, 0);
-                    // Skip applying to cols before i due to Errata 11
-                    #[cfg(not(debug_assertions))]
-                    self.fma_rows(temp + j, i, b, self.i);
-                }
+            for j in self.A.query_non_zero_columns(i, self.i) {
+                #[cfg(debug_assertions)]
+                self.fma_rows(j, i, Octet::one(), 0);
+                // Skip applying to cols before i due to Errata 11
+                #[cfg(not(debug_assertions))]
+                self.fma_rows(j, i, Octet::one(), self.i);
             }
         }
 


### PR DESCRIPTION
Previously we used column major ordering. Switch to row major to
optimize sequential access of rows which is much more common in the
first phase, and can also be used in the fourth phase

This improves performance by ~10% on large symbol counts