### PR TITLE
Build Python package with abi3 support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 serde = {version = "1.0.102", features=["std", "derive"], optional = true}
-pyo3 = {version = "0.12", features=["extension-module"], optional = true }
+pyo3 = {version = "0.13", features=["extension-module", "abi3-py36"], optional = true }
 
 [dev-dependencies]
 criterion = "0.3"
@@ -48,7 +48,7 @@ python = ["pyo3"]
 serde_support = ["serde"]
 
 [package.metadata.maturin]
-requires-python = ">= 3.5"
+requires-python = ">= 3.6"
 classifier = ["Development Status :: 4 - Beta",
               "License :: OSI Approved :: Apache Software License",
               "Programming Language :: Python",


### PR DESCRIPTION
This allows the package to be used on any Python version >= 3.6