### PR TITLE
feat: foot_gun feature, exposes parts for embed (#4)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,6 +59,8 @@ python = ["pyo3", "std"]
 serde_support = ["serde", "std"]
 std = []
 wasm = ["wasm-bindgen", "js-sys", "std"]
+foot_gun = []
+
 
 [package.metadata.maturin]
 requires-python = ">= 3.7"

--- a/src/base.rs
+++ b/src/base.rs
@@ -240,6 +240,19 @@ impl ObjectTransmissionInformation {
         }
     }
 
+    #[cfg(feature = "foot_gun")]
+    pub fn generate_encoding_parameters_exposed(
+        transfer_length: u64,
+        max_packet_size: u16,
+        decoder_memory_requirement: u64,
+    ) -> ObjectTransmissionInformation {
+        ObjectTransmissionInformation::generate_encoding_parameters(
+            transfer_length,
+            max_packet_size,
+            decoder_memory_requirement,
+        )
+    }
+
     pub fn with_defaults(
         transfer_length: u64,
         max_packet_size: u16,

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -132,7 +132,10 @@ pub struct SourceBlockDecoder {
     symbol_alignment: u8,
     source_block_symbols: u32,
     source_symbols: Vec<Option<Symbol>>,
+    #[cfg(not(feature = "foot_gun"))]
     repair_packets: Vec<EncodingPacket>,
+    #[cfg(feature = "foot_gun")]
+    pub repair_packets: Vec<EncodingPacket>,
     received_source_symbols: u32,
     received_esi: Set<u32>,
     decoded: bool,


### PR DESCRIPTION
This small fix adds a weird feature `foot_gun`, that can mess up normal usage if invoked. However, it allows a channel to optimize decoder memory usage in a way that allows a system with tiny RAM but large external storage decode payloads in-place within external memory.

I will convert this to PR when we make sure integration in Kampela project works, thus confirming that this was a good idea.

Usage: https://github.com/Alzymologist/raptorq-metal-wrap