### PR TITLE
fix: correct assertion in enc() — a1 < p1, not a < w

### DIFF
--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -389,8 +389,8 @@ fn enc(
     assert!(1 <= a && a < w);
     assert!(b < w);
     assert!(d1 == 2 || d1 == 3);
-    assert!(1 <= a1 && a < w);
-    assert!(b1 < w);
+    assert!(1 <= a1 && a1 < p1);
+    assert!(b1 < p1);
 
     let mut result = intermediate_symbols[b as usize].clone();
     for _ in 1..d {


### PR DESCRIPTION
## Why
The second pair of assertions in `enc()` checks the wrong variables:
```rust
assert!(1 <= a1 && a < w);   // bug: checks a, not a1; checks against w, not p1
assert!(b1 < w);             // bug: checks against w, not p1
```
`a1` and `b1` are indices into the PI symbol range (bounded by `p1`), not the LT symbol range (bounded by `w`).

## Fix
```rust
assert!(1 <= a1 && a1 < p1);
assert!(b1 < p1);
```

## Tests
`cargo test` — all 53 tests pass.