### PR TITLE
perf: add #[inline] annotations to hot Octet/Symbol/octets operations

### DIFF
--- a/src/octet.rs
+++ b/src/octet.rs
@@ -134,27 +134,33 @@ pub struct Octet {
 }
 
 impl Octet {
+    #[inline]
     pub fn new(value: u8) -> Octet {
         Octet { value }
     }
 
+    #[inline]
     pub fn zero() -> Octet {
         Octet { value: 0 }
     }
 
+    #[inline]
     pub fn one() -> Octet {
         Octet { value: 1 }
     }
 
+    #[inline]
     pub fn alpha(i: usize) -> Octet {
         assert!(i < 256);
         Octet { value: OCT_EXP[i] }
     }
 
+    #[inline]
     pub fn byte(&self) -> u8 {
         self.value
     }
 
+    #[inline]
     pub fn fma(&mut self, other1: &Octet, other2: &Octet) {
         if other1.value != 0 && other2.value != 0 {
             unsafe {
@@ -171,6 +177,7 @@ impl Octet {
 impl Add for Octet {
     type Output = Octet;
 
+    #[inline]
     #[allow(clippy::suspicious_arithmetic_impl)]
     fn add(self, other: Octet) -> Octet {
         Octet {
@@ -183,6 +190,7 @@ impl Add for Octet {
 impl<'b> Add<&'b Octet> for &Octet {
     type Output = Octet;
 
+    #[inline]
     #[allow(clippy::suspicious_arithmetic_impl)]
     fn add(self, other: &'b Octet) -> Octet {
         Octet {
@@ -193,6 +201,7 @@ impl<'b> Add<&'b Octet> for &Octet {
 }
 
 impl AddAssign for Octet {
+    #[inline]
     #[allow(clippy::suspicious_arithmetic_impl, clippy::suspicious_op_assign_impl)]
     fn add_assign(&mut self, other: Octet) {
         self.value ^= other.value;
@@ -200,6 +209,7 @@ impl AddAssign for Octet {
 }
 
 impl<'a> AddAssign<&'a Octet> for Octet {
+    #[inline]
     #[allow(clippy::suspicious_arithmetic_impl, clippy::suspicious_op_assign_impl)]
     fn add_assign(&mut self, other: &'a Octet) {
         self.value ^= other.value;
@@ -209,6 +219,7 @@ impl<'a> AddAssign<&'a Octet> for Octet {
 impl Sub for Octet {
     type Output = Octet;
 
+    #[inline]
     #[allow(clippy::suspicious_arithmetic_impl)]
     fn sub(self, rhs: Octet) -> Octet {
         Octet {
@@ -221,6 +232,7 @@ impl Sub for Octet {
 impl Mul for Octet {
     type Output = Octet;
 
+    #[inline]
     fn mul(self, other: Octet) -> Octet {
         &self * &other
     }
@@ -229,6 +241,7 @@ impl Mul for Octet {
 impl<'b> Mul<&'b Octet> for &Octet {
     type Output = Octet;
 
+    #[inline]
     #[allow(clippy::suspicious_arithmetic_impl)]
     fn mul(self, other: &'b Octet) -> Octet {
         // As defined in section 5.7.2, multiplication is implemented via the tables above

--- a/src/octets.rs
+++ b/src/octets.rs
@@ -82,6 +82,7 @@ impl BinaryOctetVec {
     }
 }
 
+#[inline]
 pub fn fused_addassign_mul_scalar_binary(
     octets: &mut [u8],
     other: &BinaryOctetVec,
@@ -415,6 +416,7 @@ unsafe fn mulassign_scalar_ssse3(octets: &mut [u8], scalar: &Octet) {
     }
 }
 
+#[inline]
 pub fn mulassign_scalar(octets: &mut [u8], scalar: &Octet) {
     #[cfg(all(any(target_arch = "x86", target_arch = "x86_64"), feature = "std"))]
     {
@@ -611,6 +613,7 @@ unsafe fn fused_addassign_mul_scalar_ssse3(octets: &mut [u8], other: &[u8], scal
     }
 }
 
+#[inline]
 pub fn fused_addassign_mul_scalar(octets: &mut [u8], other: &[u8], scalar: &Octet) {
     debug_assert_ne!(
         *scalar,
@@ -834,6 +837,7 @@ unsafe fn add_assign_ssse3(octets: &mut [u8], other: &[u8]) {
     }
 }
 
+#[inline]
 pub fn add_assign(octets: &mut [u8], other: &[u8]) {
     #[cfg(all(any(target_arch = "x86", target_arch = "x86_64"), feature = "std"))]
     {

--- a/src/symbol.rs
+++ b/src/symbol.rs
@@ -47,6 +47,7 @@ impl Symbol {
     }
 
     /// Return the underlying byte slice for a symbol.
+    #[inline]
     pub fn as_bytes(&self) -> &[u8] {
         &self.value
     }
@@ -56,16 +57,19 @@ impl Symbol {
         self.value
     }
 
+    #[inline]
     pub fn mulassign_scalar(&mut self, scalar: &Octet) {
         mulassign_scalar(&mut self.value, scalar);
     }
 
+    #[inline]
     pub fn fused_addassign_mul_scalar(&mut self, other: &Symbol, scalar: &Octet) {
         fused_addassign_mul_scalar(&mut self.value, &other.value, scalar);
     }
 }
 
 impl<'a> AddAssign<&'a Symbol> for Symbol {
+    #[inline]
     fn add_assign(&mut self, other: &'a Symbol) {
         add_assign(&mut self.value, &other.value);
     }

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,4 +1,5 @@
 // Get two non-overlapping ranges starting at i & j, both with length len
+#[inline]
 pub fn get_both_ranges<T>(
     vector: &mut [T],
     i: usize,
@@ -19,6 +20,7 @@ pub fn get_both_ranges<T>(
     }
 }
 
+#[inline]
 pub fn get_both_indices<T>(vector: &mut [T], i: usize, j: usize) -> (&mut T, &mut T) {
     debug_assert_ne!(i, j);
     debug_assert!(i < vector.len());
@@ -37,6 +39,7 @@ pub fn get_both_indices<T>(vector: &mut [T], i: usize, j: usize) -> (&mut T, &mu
 // (1) the result is known to not overflow u32 from elsewhere;
 // (2) `denom` is known to not be `0` from elsewhere.
 // TODO this is definitely not always the case! Let's do something about it.
+#[inline]
 pub fn int_div_ceil(num: u64, denom: u64) -> u32 {
     if num.is_multiple_of(denom) {
         (num / denom) as u32


### PR DESCRIPTION
## Why
Hot SIMD dispatch functions (`mulassign_scalar`, `add_assign`, `fused_addassign_mul_scalar`) and their `Octet`/`Symbol` wrappers are not inlined by default. Since these operate on small data (512-byte symbols), call overhead is significant relative to the actual work.

## How
Add `#[inline]` to:
- All `Octet` arithmetic ops (`Add`, `AddAssign`, `Sub`, `Mul`, `fma`, `new`, `zero`, `one`, `alpha`, `byte`)
- `Symbol::mulassign_scalar`, `Symbol::fused_addassign_mul_scalar`, `Symbol::AddAssign`, `Symbol::as_bytes`
- Top-level octets functions: `mulassign_scalar`, `add_assign`, `fused_addassign_mul_scalar`, `fused_addassign_mul_scalar_binary`
- `util::get_both_ranges`, `util::get_both_indices`, `util::int_div_ceil`

No unsafe code. No behavioral changes.

## Benchmark (AMD EPYC 9654P, Zen 4)
| Benchmark | Baseline | This PR | Delta |
|-----------|----------|---------|-------|
| mulassign_scalar (512B) | 22.7 ns | 17.4 ns | **-23%** |
| Symbol += (512B) | 22.4 ns | 18.3 ns | **-18%** |
| Symbol FMA (512B) | 24.6 ns | 19.8 ns | **-19%** |
| encode 10KB | 37.1 µs | 37.2 µs | 0% |
| roundtrip 10KB | 39.0 µs | 38.4 µs | -1% |
| roundtrip repair 10KB | 79.9 µs | 80.0 µs | 0% |

The improvement is entirely in per-symbol operation overhead. Macro benchmarks are unaffected because they are dominated by plan generation at this data size.

## Tests
`cargo test` — all 53 tests pass.