### PR TITLE
chore: fix dead_code and lifetime elision warnings

### DIFF
--- a/src/arraymap.rs
+++ b/src/arraymap.rs
@@ -27,6 +27,7 @@ impl ImmutableListMap {
         &self.values[start..end]
     }
 
+    #[allow(dead_code)]
     pub fn size_in_bytes(&self) -> usize {
         let mut bytes = size_of::<Self>();
         bytes += size_of::<u32>() * self.offsets.len();

--- a/src/matrix.rs
+++ b/src/matrix.rs
@@ -29,7 +29,7 @@ pub trait BinaryMatrix: Clone {
     fn count_ones(&self, row: usize, start_col: usize, end_col: usize) -> usize;
 
     // Once "impl Trait" is supported in traits, it would be better to return "impl Iterator<...>"
-    fn get_row_iter(&self, row: usize, start_col: usize, end_col: usize) -> OctetIter;
+    fn get_row_iter(&self, row: usize, start_col: usize, end_col: usize) -> OctetIter<'_>;
 
     // An iterator over rows with a 1-valued entry for the given col
     fn get_ones_in_column(&self, col: usize, start_row: usize, end_row: usize) -> Vec<u32>;
@@ -177,7 +177,7 @@ impl BinaryMatrix for DenseBinaryMatrix {
         return ones as usize;
     }
 
-    fn get_row_iter(&self, row: usize, start_col: usize, end_col: usize) -> OctetIter {
+    fn get_row_iter(&self, row: usize, start_col: usize, end_col: usize) -> OctetIter<'_> {
         let (first_word, first_bit) = self.bit_position(row, start_col);
         let (last_word, _) = self.bit_position(row, end_col);
         OctetIter::new_dense_binary(

--- a/src/sparse_matrix.rs
+++ b/src/sparse_matrix.rs
@@ -253,7 +253,7 @@ impl BinaryMatrix for SparseBinaryMatrix {
         }
     }
 
-    fn get_row_iter(&self, row: usize, start_col: usize, end_col: usize) -> OctetIter {
+    fn get_row_iter(&self, row: usize, start_col: usize, end_col: usize) -> OctetIter<'_> {
         if end_col > self.width - self.num_dense_columns {
             unimplemented!(
                 "It was assumed that this wouldn't be needed, because the method would only be called on the V section of matrix A"

--- a/src/sparse_vec.rs
+++ b/src/sparse_vec.rs
@@ -30,6 +30,7 @@ impl SparseBinaryVec {
         self.elements.binary_search(&i)
     }
 
+    #[allow(dead_code)]
     pub fn size_in_bytes(&self) -> usize {
         size_of::<Self>() + size_of::<u16>() * self.elements.len()
     }


### PR DESCRIPTION
## Why
- `ImmutableListMap::size_in_bytes()` and `SparseBinaryVec::size_in_bytes()` trigger `dead_code` warnings when compiled without all features
- `OctetIter` return types use the old elided lifetime style that newer Rust versions warn about

## How
- Add `#[allow(dead_code)]` to `size_in_bytes()` in `arraymap.rs` and `sparse_vec.rs`
- Change `OctetIter` to `OctetIter<'_>` in trait definition and impls (`matrix.rs`, `sparse_matrix.rs`)

4 files, 5 lines changed. No behavioral changes.

## Tests
`cargo test` — all 53 tests pass.