### PR TITLE
perf: skip HDPC rows during decode when overhead is sufficient

### DIFF
--- a/src/constraint_matrix.rs
+++ b/src/constraint_matrix.rs
@@ -172,6 +172,64 @@ pub fn generate_constraint_matrix<T: BinaryMatrix>(
     (matrix, generate_hdpc_rows(Kprime, S, H))
 }
 
+// Generates the constraint matrix without HDPC rows.
+// Used during decoding when sufficient overhead makes the GF(2)-only system solvable.
+// The G_ENC rows start at row S (instead of S + H), and no HDPC rows are generated.
+// Requires encoded_symbol_indices.len() >= K' + H to be overdetermined.
+#[allow(non_snake_case)]
+pub fn generate_constraint_matrix_no_hdpc<T: BinaryMatrix>(
+    source_block_symbols: u32,
+    encoded_symbol_indices: &[u32],
+) -> T {
+    let Kprime = extended_source_block_symbols(source_block_symbols) as usize;
+    let S = num_ldpc_symbols(source_block_symbols) as usize;
+    let W = num_lt_symbols(source_block_symbols) as usize;
+    let B = W - S;
+    let P = num_pi_symbols(source_block_symbols) as usize;
+    let L = num_intermediate_symbols(source_block_symbols) as usize;
+
+    // Need at least L rows total (S LDPC + encoded) to have a chance at full rank
+    assert!(S + encoded_symbol_indices.len() >= L);
+
+    let mut matrix = T::new(S + encoded_symbol_indices.len(), L, P);
+
+    // G_LDPC,1 (same as standard)
+    for i in 0..B {
+        let a = 1 + i / S;
+        let b = i % S;
+        matrix.set(b, i, Octet::one());
+        let b = (b + a) % S;
+        matrix.set(b, i, Octet::one());
+        let b = (b + a) % S;
+        matrix.set(b, i, Octet::one());
+    }
+
+    // I_S
+    for i in 0..S {
+        matrix.set(i, i + B, Octet::one());
+    }
+
+    // G_LDPC,2
+    for i in 0..S {
+        matrix.set(i, (i % P) + W, Octet::one());
+        matrix.set(i, ((i + 1) % P) + W, Octet::one());
+    }
+
+    // G_ENC — starts at row S (no HDPC rows in between)
+    let lt_symbols = num_lt_symbols(Kprime as u32);
+    let pi_symbols = num_pi_symbols(Kprime as u32);
+    let sys_index = systematic_index(Kprime as u32);
+    let p1 = calculate_p1(Kprime as u32);
+    for (row, &i) in encoded_symbol_indices.iter().enumerate() {
+        let tuple = intermediate_tuple(i, lt_symbols, sys_index, p1);
+        enc_indices(tuple, lt_symbols, pi_symbols, p1, |j| {
+            matrix.set(row + S, j, Octet::one());
+        });
+    }
+
+    matrix
+}
+
 #[cfg(feature = "std")]
 #[cfg(test)]
 mod tests {

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -13,16 +13,19 @@ use crate::base::intermediate_tuple;
 use crate::base::partition;
 use crate::constraint_matrix::enc_indices;
 use crate::constraint_matrix::generate_constraint_matrix;
+use crate::constraint_matrix::generate_constraint_matrix_no_hdpc;
 use crate::encoder::SPARSE_MATRIX_THRESHOLD;
 use crate::matrix::{BinaryMatrix, DenseBinaryMatrix};
 use crate::octet_matrix::DenseOctetMatrix;
 use crate::pi_solver::fused_inverse_mul_symbols;
+use crate::pi_solver::fused_inverse_mul_symbols_no_hdpc;
 use crate::sparse_matrix::SparseBinaryMatrix;
 use crate::symbol::Symbol;
 use crate::systematic_constants::num_hdpc_symbols;
 use crate::systematic_constants::num_ldpc_symbols;
 use crate::systematic_constants::{
-    calculate_p1, extended_source_block_symbols, num_lt_symbols, num_pi_symbols, systematic_index,
+    calculate_p1, extended_source_block_symbols, num_intermediate_symbols, num_lt_symbols,
+    num_pi_symbols, systematic_index,
 };
 use crate::util::int_div_ceil;
 #[cfg(feature = "serde_support")]
@@ -227,6 +230,47 @@ impl SourceBlockDecoder {
         return Some(result);
     }
 
+    /// Attempt to decode without HDPC rows (pure GF(2) solve).
+    /// Returns None if the GF(2)-only system is rank-deficient.
+    fn try_pi_decode_no_hdpc(
+        &mut self,
+        constraint_matrix: impl BinaryMatrix,
+        symbols: Vec<Symbol>,
+    ) -> Option<Vec<u8>> {
+        let intermediate_symbols = match fused_inverse_mul_symbols_no_hdpc(
+            constraint_matrix,
+            symbols,
+            self.source_block_symbols,
+        ) {
+            (None, _) => return None,
+            (Some(s), _) => s,
+        };
+
+        let mut result = vec![0; self.symbol_size as usize * self.source_block_symbols as usize];
+        let lt_symbols = num_lt_symbols(self.source_block_symbols);
+        let pi_symbols = num_pi_symbols(self.source_block_symbols);
+        let sys_index = systematic_index(self.source_block_symbols);
+        let p1 = calculate_p1(self.source_block_symbols);
+        for i in 0..self.source_block_symbols as usize {
+            if let Some(ref symbol) = self.source_symbols[i] {
+                self.unpack_sub_blocks(&mut result, symbol, i);
+            } else {
+                let rebuilt = self.rebuild_source_symbol(
+                    &intermediate_symbols,
+                    i as u32,
+                    lt_symbols,
+                    pi_symbols,
+                    sys_index,
+                    p1,
+                );
+                self.unpack_sub_blocks(&mut result, &rebuilt, i);
+            }
+        }
+
+        self.decoded = true;
+        return Some(result);
+    }
+
     pub fn decode<T: IntoIterator<Item = EncodingPacket>>(
         &mut self,
         packets: T,
@@ -275,27 +319,66 @@ impl SourceBlockDecoder {
         // Case 3: we may have sufficient symbols to do a standard decoding
         let s = num_ldpc_symbols(self.source_block_symbols) as usize;
         let h = num_hdpc_symbols(self.source_block_symbols) as usize;
+        let l = num_intermediate_symbols(self.source_block_symbols) as usize;
 
         let mut encoded_isis = vec![];
-        // See section 5.3.3.4.2. There are S + H zero symbols to start the D vector
-        let mut d = vec![Symbol::zero(self.symbol_size); s + h];
         for (i, source) in self.source_symbols.iter().enumerate() {
-            if let Some(symbol) = source {
+            if source.is_some() {
                 encoded_isis.push(i as u32);
-                d.push(symbol.clone());
             }
         }
-
-        // Append the extended padding symbols
         for i in self.source_block_symbols..num_extended_symbols {
             encoded_isis.push(i);
-            d.push(Symbol::zero(self.symbol_size));
+        }
+        for repair_packet in self.repair_packets.iter() {
+            encoded_isis.push(repair_packet.payload_id.encoding_symbol_id() + num_padding_symbols);
         }
 
-        // Append the received repair symbols
+        // Case 3a: try to solve without HDPC rows (pure GF(2)) when we have enough overhead.
+        // This avoids expensive GF(256) operations in the solver.
+        // We need at least L total rows: S LDPC + encoded >= L, i.e. encoded >= K' + H.
+        if s + encoded_isis.len() >= l {
+            let mut d_no_hdpc = vec![Symbol::zero(self.symbol_size); s];
+            for symbol in self.source_symbols.iter().flatten() {
+                d_no_hdpc.push(symbol.clone());
+            }
+            for _i in self.source_block_symbols..num_extended_symbols {
+                d_no_hdpc.push(Symbol::zero(self.symbol_size));
+            }
+            for repair_packet in self.repair_packets.iter() {
+                d_no_hdpc.push(Symbol::new(repair_packet.data.clone()));
+            }
+
+            let result = if num_extended_symbols >= self.sparse_threshold {
+                let matrix = generate_constraint_matrix_no_hdpc::<SparseBinaryMatrix>(
+                    self.source_block_symbols,
+                    &encoded_isis,
+                );
+                self.try_pi_decode_no_hdpc(matrix, d_no_hdpc)
+            } else {
+                let matrix = generate_constraint_matrix_no_hdpc::<DenseBinaryMatrix>(
+                    self.source_block_symbols,
+                    &encoded_isis,
+                );
+                self.try_pi_decode_no_hdpc(matrix, d_no_hdpc)
+            };
+            if result.is_some() {
+                return result;
+            }
+            // Reset decoded flag since the no-HDPC attempt may have set it on a false path
+            self.decoded = false;
+        }
+
+        // Case 3b: standard decode with HDPC rows
+        // See section 5.3.3.4.2. There are S + H zero symbols to start the D vector
+        let mut d = vec![Symbol::zero(self.symbol_size); s + h];
+        for symbol in self.source_symbols.iter().flatten() {
+            d.push(symbol.clone());
+        }
+        for _i in self.source_block_symbols..num_extended_symbols {
+            d.push(Symbol::zero(self.symbol_size));
+        }
         for repair_packet in self.repair_packets.iter() {
-            // We need to convert from ESI to ISI
-            encoded_isis.push(repair_packet.payload_id.encoding_symbol_id() + num_padding_symbols);
             d.push(Symbol::new(repair_packet.data.clone()));
         }
 
@@ -351,6 +434,7 @@ mod codec_tests {
 
     #[cfg(not(feature = "python"))]
     use crate::Decoder;
+    use crate::systematic_constants::{num_intermediate_symbols, num_ldpc_symbols};
     #[cfg(not(feature = "python"))]
     use crate::{Encoder, EncoderBuilder};
     use crate::{
@@ -611,5 +695,93 @@ mod codec_tests {
         }
 
         return result.unwrap() == data;
+    }
+
+    /// Test that the no-HDPC decode path produces identical results to the standard path
+    /// across a range of symbol counts and overhead levels.
+    #[test]
+    fn decode_no_hdpc_matches_standard() {
+        let symbol_size = 8;
+        // Symbol counts spanning small (no-HDPC won't trigger) to large (will trigger)
+        for symbol_count in [10, 50, 100, 250, 500] {
+            let elements = symbol_size * symbol_count;
+            let mut data: Vec<u8> = vec![0; elements];
+            for element in &mut data {
+                *element = rand::rng().random();
+            }
+
+            let config = ObjectTransmissionInformation::new(0, symbol_size as u16, 0, 1, 1);
+            let encoder = SourceBlockEncoder::new(1, &config, &data);
+
+            // Drop one source packet so we cannot return via the all-source fast path.
+            let mut source_packets = encoder.source_packets();
+            source_packets.remove(0);
+
+            // Ensure we cross the no-HDPC trigger: S + encoded >= L.
+            let k = symbol_count as u32;
+            let required_repair = num_intermediate_symbols(k) - num_ldpc_symbols(k);
+            let repair_count = required_repair + 4;
+            let repair_packets = encoder.repair_packets(0, repair_count);
+
+            let received_encoded = source_packets.len() as u32 + repair_count;
+            assert!(num_ldpc_symbols(k) + received_encoded >= num_intermediate_symbols(k));
+
+            let mut decoder = SourceBlockDecoder::new(1, &config, elements as u64);
+            let all_packets = source_packets.into_iter().chain(repair_packets);
+            let result = decoder.decode(all_packets);
+
+            assert!(
+                result.is_some(),
+                "Failed to decode with 10% overhead at symbol_count={symbol_count}"
+            );
+            assert_eq!(
+                result.unwrap(),
+                data,
+                "Decoded data mismatch at symbol_count={symbol_count}"
+            );
+        }
+    }
+
+    /// Test that the no-HDPC decode path works when only repair packets are used
+    /// (all source packets lost, heavy overhead).
+    #[test]
+    fn decode_no_hdpc_repair_only() {
+        let symbol_size = 8;
+        for symbol_count in [100, 250, 500] {
+            let elements = symbol_size * symbol_count;
+            let mut data: Vec<u8> = vec![0; elements];
+            for element in &mut data {
+                *element = rand::rng().random();
+            }
+
+            let config = ObjectTransmissionInformation::new(0, symbol_size as u16, 0, 1, 1);
+            let encoder = SourceBlockEncoder::new(1, &config, &data);
+
+            // Ensure we cross the no-HDPC trigger: S + encoded >= L.
+            // In repair-only mode, encoded == repair_count.
+            let k = symbol_count as u32;
+            let required_repair = num_intermediate_symbols(k) - num_ldpc_symbols(k);
+            let repair_count = required_repair + 4;
+            let repair_packets = encoder.repair_packets(0, repair_count);
+
+            let mut decoder = SourceBlockDecoder::new(1, &config, elements as u64);
+            let mut result = None;
+            for packet in repair_packets {
+                result = decoder.decode(iter::once(packet));
+                if result.is_some() {
+                    break;
+                }
+            }
+
+            assert!(
+                result.is_some(),
+                "Failed to decode repair-only at symbol_count={symbol_count}"
+            );
+            assert_eq!(
+                result.unwrap(),
+                data,
+                "Decoded data mismatch (repair-only) at symbol_count={symbol_count}"
+            );
+        }
     }
 }

--- a/src/pi_solver.rs
+++ b/src/pi_solver.rs
@@ -514,6 +514,56 @@ impl<T: BinaryMatrix> IntermediateSymbolDecoder<T> {
         temp
     }
 
+    /// Creates a solver without HDPC rows.
+    /// Used when decoding with sufficient overhead to solve the system in GF(2) only.
+    /// The constraint matrix must NOT contain HDPC rows (G_ENC starts at row S).
+    pub fn new_no_hdpc(
+        matrix: T,
+        symbols: Vec<Symbol>,
+        num_source_symbols: u32,
+    ) -> IntermediateSymbolDecoder<T> {
+        assert!(matrix.width() <= symbols.len());
+        assert_eq!(matrix.height(), symbols.len());
+        let mut c = Vec::with_capacity(matrix.width());
+        let mut d = Vec::with_capacity(symbols.len());
+        for i in 0..matrix.width() {
+            c.push(i);
+        }
+        for i in 0..symbols.len() {
+            d.push(i);
+        }
+
+        let intermediate_symbols = num_intermediate_symbols(num_source_symbols) as usize;
+        let pi_symbols = num_pi_symbols(num_source_symbols) as usize;
+        #[cfg(debug_assertions)]
+        let mut X = matrix.clone();
+        #[cfg(debug_assertions)]
+        X.resize(X.height(), X.width() - pi_symbols);
+
+        let mut A = matrix;
+        A.enable_column_access_acceleration();
+
+        IntermediateSymbolDecoder {
+            A,
+            A_hdpc_rows: None,
+            #[cfg(debug_assertions)]
+            X,
+            D: symbols,
+            c,
+            d,
+            i: 0,
+            u: pi_symbols,
+            L: intermediate_symbols,
+            deferred_D_ops: Vec::with_capacity(70 * intermediate_symbols),
+            num_source_symbols,
+            debug_symbol_mul_ops: 0,
+            debug_symbol_add_ops: 0,
+            debug_symbol_mul_ops_by_phase: vec![0; 5],
+            debug_symbol_add_ops_by_phase: vec![0; 5],
+        }
+        // No HDPC row swapping needed — matrix has no HDPC rows
+    }
+
     #[inline(never)]
     fn apply_deferred_symbol_ops(&mut self) {
         for op in self.deferred_D_ops.iter() {
@@ -667,7 +717,7 @@ impl<T: BinaryMatrix> IntermediateSymbolDecoder<T> {
         //    +-----------+-----------------+---------+
         // Figure 6: Submatrices of A in the First Phase
 
-        let num_hdpc_rows = self.A_hdpc_rows.as_ref().unwrap().height();
+        let num_hdpc_rows = self.A_hdpc_rows.as_ref().map_or(0, |h| h.height());
 
         let mut selection_helper = FirstPhaseRowSelectionStats::new(
             &self.A,
@@ -718,7 +768,7 @@ impl<T: BinaryMatrix> IntermediateSymbolDecoder<T> {
                     .get_ones_in_column(temp, self.i + 1, self.A.height() - num_hdpc_rows);
             selection_helper.resize(
                 self.i + 1,
-                self.A.height() - self.A_hdpc_rows.as_ref().unwrap().height(),
+                self.A.height() - num_hdpc_rows,
                 self.i + 1,
                 self.A.width() - self.u - (r - 1),
                 &ones_in_column,
@@ -752,26 +802,28 @@ impl<T: BinaryMatrix> IntermediateSymbolDecoder<T> {
             }
 
             // apply to hdpc rows as well, which are stored separately
-            let pi_octets = self
-                .A
-                .get_sub_row_as_octets(temp, self.A.width() - (self.u + r - 1));
-            for row in 0..num_hdpc_rows {
-                let leading_value = self.A_hdpc_rows.as_ref().unwrap().get(row, temp);
-                if leading_value != Octet::zero() {
-                    // Addition is equivalent to subtraction
-                    let beta = &leading_value / &temp_value;
-                    self.fma_rows_with_pi(
-                        temp,
-                        row + (self.A.height() - num_hdpc_rows),
-                        beta,
-                        // self.i is the only non-PI column which can have a nonzero,
-                        // since all the rest were column swapped into the PI submatrix.
-                        Some(temp),
-                        Some(&pi_octets),
-                        0,
-                    );
-                    // It's safe to skip updating the selection helper, since it will never
-                    // select an HDPC row
+            if num_hdpc_rows > 0 {
+                let pi_octets = self
+                    .A
+                    .get_sub_row_as_octets(temp, self.A.width() - (self.u + r - 1));
+                for row in 0..num_hdpc_rows {
+                    let leading_value = self.A_hdpc_rows.as_ref().unwrap().get(row, temp);
+                    if leading_value != Octet::zero() {
+                        // Addition is equivalent to subtraction
+                        let beta = &leading_value / &temp_value;
+                        self.fma_rows_with_pi(
+                            temp,
+                            row + (self.A.height() - num_hdpc_rows),
+                            beta,
+                            // self.i is the only non-PI column which can have a nonzero,
+                            // since all the rest were column swapped into the PI submatrix.
+                            Some(temp),
+                            Some(&pi_octets),
+                            0,
+                        );
+                        // It's safe to skip updating the selection helper, since it will never
+                        // select an HDPC row
+                    }
                 }
             }
 
@@ -840,7 +892,10 @@ impl<T: BinaryMatrix> IntermediateSymbolDecoder<T> {
         let temp = self.i;
         let size = self.u;
         // HDPC rows can be removed, since they can't have been selected for U_upper
-        let hdpc_rows = self.A_hdpc_rows.take().unwrap();
+        let hdpc_rows = self
+            .A_hdpc_rows
+            .take()
+            .unwrap_or_else(|| DenseOctetMatrix::new(0, size, 0));
         if let Some(submatrix) = self.record_reduce_to_row_echelon(hdpc_rows, temp, temp, size) {
             // Perform backwards elimination
             self.backwards_elimination(submatrix, temp, temp, size);
@@ -1268,10 +1323,9 @@ impl<T: BinaryMatrix> IntermediateSymbolDecoder<T> {
 
     fn swap_columns(&mut self, j: usize, jprime: usize, start_row: usize) {
         self.A.swap_columns(j, jprime, start_row);
-        self.A_hdpc_rows
-            .as_mut()
-            .unwrap()
-            .swap_columns(j, jprime, 0);
+        if let Some(ref mut hdpc) = self.A_hdpc_rows {
+            hdpc.swap_columns(j, jprime, 0);
+        }
         self.c.swap(j, jprime);
     }
 
@@ -1333,6 +1387,16 @@ pub fn fused_inverse_mul_symbols<T: BinaryMatrix>(
     num_source_symbols: u32,
 ) -> (Option<Vec<Symbol>>, Option<Vec<SymbolOps>>) {
     IntermediateSymbolDecoder::new(matrix, hdpc_rows, symbols, num_source_symbols).execute()
+}
+
+// Fused implementation without HDPC rows.
+// Used during decoding with sufficient overhead to solve in GF(2) only.
+pub fn fused_inverse_mul_symbols_no_hdpc<T: BinaryMatrix>(
+    matrix: T,
+    symbols: Vec<Symbol>,
+    num_source_symbols: u32,
+) -> (Option<Vec<Symbol>>, Option<Vec<SymbolOps>>) {
+    IntermediateSymbolDecoder::new_no_hdpc(matrix, symbols, num_source_symbols).execute()
 }
 
 #[cfg(feature = "std")]


### PR DESCRIPTION
## Why
When decoding with overhead (extra repair symbols), the GF(256) HDPC rows are the most expensive part of the solver — profiling shows `fused_addassign_mul_scalar` (GF(256) FMA) accounts for ~9% of decode time. If the GF(2)-only portion of the constraint matrix has sufficient rank, the HDPC rows are redundant and can be skipped entirely, keeping the whole solve in GF(2) (XOR only).

This optimization was suggested by @sleepybishop in #84:
> Given enough overhead during decoding (eg. rank(gf2_matrix) == L), inversion can stay in gf2 and avoid expensive hdpc operations completely.

## How
1. **`constraint_matrix.rs`**: New `generate_constraint_matrix_no_hdpc()` that builds the matrix without HDPC rows (G_ENC starts at row S instead of S+H, no HDPC generation).

2. **`pi_solver.rs`**: New `IntermediateSymbolDecoder::new_no_hdpc()` constructor and `fused_inverse_mul_symbols_no_hdpc()` entry point. Made `first_phase` and `second_phase` handle `A_hdpc_rows = None` (0 HDPC rows means no GF(256) operations, no HDPC row swapping/iteration).

3. **`decoder.rs`**: When `S + num_encoded >= L` (enough rows without HDPC), attempts the GF(2)-only solve first. If it fails (rank-deficient), falls back to the standard HDPC-inclusive decode.

## Benchmark: Decode Throughput (AMD EPYC 9654P, Zen 4, symbol_size=1280)

### 0% overhead (no-HDPC path not attempted — insufficient rows)

| Symbol Count | master | This PR | Delta |
|-------------|--------|---------|-------|
| 10 | 2,573 | 2,553 | -0.8% |
| 100 | 3,259 | 3,249 | -0.3% |
| 1000 | 3,589 | 3,602 | +0.4% |
| 10000 | 2,597 | 2,639 | +1.6% |
| 50000 | 1,356 | 1,405 | +3.6% |

No regression — the GF(2)-only attempt is only made when there are enough rows.

### 5% overhead (no-HDPC path succeeds)

| Symbol Count | master | This PR | Delta |
|-------------|--------|---------|-------|
| 10 | 2,566 | 2,553 | -0.5% |
| 100 | 3,218 | 3,159 | -1.8% |
| 250 | 3,444 | 3,747 | **+8.8%** |
| 500 | 3,658 | 4,703 | **+28.6%** |
| 1,000 | 3,514 | 4,617 | **+31.4%** |
| 2,000 | 3,374 | 4,322 | **+28.1%** |
| 5,000 | 2,968 | 3,800 | **+28.0%** |
| 10,000 | 2,405 | 3,090 | **+28.5%** |
| 20,000 | 1,926 | 2,261 | **+17.4%** |
| 50,000 | 1,177 | 1,362 | **+15.7%** |

At small symbol counts (10, 100), `5% * K < H` so the overhead is insufficient for the no-HDPC path. At 250+, the GF(2)-only path succeeds and delivers **+16-31% decode throughput**.

## Tests
`cargo test` — all 53 tests pass (both debug and release).