### PR TITLE
perf: use contiguous SymbolSlab storage in encoder/decoder hot paths

### DIFF
--- a/benches/matrix_sparsity.rs
+++ b/benches/matrix_sparsity.rs
@@ -1,6 +1,6 @@
 use raptorq::IntermediateSymbolDecoder;
 use raptorq::Octet;
-use raptorq::Symbol;
+use raptorq::SymbolSlab;
 use raptorq::generate_constraint_matrix;
 use raptorq::{BinaryMatrix, SparseBinaryMatrix, extended_source_block_symbols};
 
@@ -55,7 +55,7 @@ fn main() {
             100.0 * density as f64 / (a.height() * a.width()) as f64
         );
 
-        let symbols = vec![Symbol::zero(1usize); a.width()];
+        let symbols = SymbolSlab::with_zeros(a.width(), 1);
         let mut decoder = IntermediateSymbolDecoder::new(a, hdpc, symbols, num_symbols);
         println!(
             "Initial memory usage: {}KB",

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -17,10 +17,12 @@ use crate::constraint_matrix::generate_constraint_matrix_no_hdpc;
 use crate::encoder::SPARSE_MATRIX_THRESHOLD;
 use crate::matrix::{BinaryMatrix, DenseBinaryMatrix};
 use crate::octet_matrix::DenseOctetMatrix;
+use crate::octets::add_assign;
 use crate::pi_solver::fused_inverse_mul_symbols;
 use crate::pi_solver::fused_inverse_mul_symbols_no_hdpc;
 use crate::sparse_matrix::SparseBinaryMatrix;
 use crate::symbol::Symbol;
+use crate::symbol_slab::SymbolSlab;
 use crate::systematic_constants::num_hdpc_symbols;
 use crate::systematic_constants::num_ldpc_symbols;
 use crate::systematic_constants::{
@@ -139,6 +141,13 @@ pub struct SourceBlockDecoder {
     sparse_threshold: u32,
 }
 
+#[derive(Copy, Clone)]
+struct EncodingParameters {
+    lt_symbols: u32,
+    pi_symbols: u32,
+    sys_index: u32,
+    p1: u32,
+}
 impl SourceBlockDecoder {
     pub fn new(
         source_block_id: u8,
@@ -167,7 +176,7 @@ impl SourceBlockDecoder {
         self.sparse_threshold = value;
     }
 
-    fn unpack_sub_blocks(&self, result: &mut [u8], symbol: &Symbol, symbol_index: usize) {
+    fn unpack_sub_blocks(&self, result: &mut [u8], symbol: &[u8], symbol_index: usize) {
         let (tl, ts, nl, ns) = partition(
             (self.symbol_size / self.symbol_alignment as u16) as u32,
             self.num_sub_blocks,
@@ -183,7 +192,7 @@ impl SourceBlockDecoder {
             };
             let start = sub_block_offset + bytes * symbol_index;
             result[start..start + bytes]
-                .copy_from_slice(&symbol.as_bytes()[symbol_offset..symbol_offset + bytes]);
+                .copy_from_slice(&symbol[symbol_offset..symbol_offset + bytes]);
             symbol_offset += bytes;
             sub_block_offset += bytes * self.source_block_symbols as usize;
         }
@@ -193,7 +202,7 @@ impl SourceBlockDecoder {
         &mut self,
         constraint_matrix: impl BinaryMatrix,
         hdpc_rows: DenseOctetMatrix,
-        symbols: Vec<Symbol>,
+        symbols: SymbolSlab,
     ) -> Option<Vec<u8>> {
         let intermediate_symbols = match fused_inverse_mul_symbols(
             constraint_matrix,
@@ -206,23 +215,25 @@ impl SourceBlockDecoder {
         };
 
         let mut result = vec![0; self.symbol_size as usize * self.source_block_symbols as usize];
-        let lt_symbols = num_lt_symbols(self.source_block_symbols);
-        let pi_symbols = num_pi_symbols(self.source_block_symbols);
-        let sys_index = systematic_index(self.source_block_symbols);
-        let p1 = calculate_p1(self.source_block_symbols);
+        let params = EncodingParameters {
+            lt_symbols: num_lt_symbols(self.source_block_symbols),
+            pi_symbols: num_pi_symbols(self.source_block_symbols),
+            sys_index: systematic_index(self.source_block_symbols),
+            p1: calculate_p1(self.source_block_symbols),
+        };
+        let ss = self.symbol_size as usize;
+        let mut rebuilt_buf = vec![0u8; ss];
         for i in 0..self.source_block_symbols as usize {
             if let Some(ref symbol) = self.source_symbols[i] {
-                self.unpack_sub_blocks(&mut result, symbol, i);
+                self.unpack_sub_blocks(&mut result, symbol.as_bytes(), i);
             } else {
-                let rebuilt = self.rebuild_source_symbol(
+                self.rebuild_source_symbol_into(
+                    &mut rebuilt_buf,
                     &intermediate_symbols,
                     i as u32,
-                    lt_symbols,
-                    pi_symbols,
-                    sys_index,
-                    p1,
+                    params,
                 );
-                self.unpack_sub_blocks(&mut result, &rebuilt, i);
+                self.unpack_sub_blocks(&mut result, &rebuilt_buf, i);
             }
         }
 
@@ -247,28 +258,41 @@ impl SourceBlockDecoder {
         };
 
         let mut result = vec![0; self.symbol_size as usize * self.source_block_symbols as usize];
-        let lt_symbols = num_lt_symbols(self.source_block_symbols);
-        let pi_symbols = num_pi_symbols(self.source_block_symbols);
-        let sys_index = systematic_index(self.source_block_symbols);
-        let p1 = calculate_p1(self.source_block_symbols);
+        let params = EncodingParameters {
+            lt_symbols: num_lt_symbols(self.source_block_symbols),
+            pi_symbols: num_pi_symbols(self.source_block_symbols),
+            sys_index: systematic_index(self.source_block_symbols),
+            p1: calculate_p1(self.source_block_symbols),
+        };
+        let mut rebuilt_buf = vec![0u8; self.symbol_size as usize];
         for i in 0..self.source_block_symbols as usize {
             if let Some(ref symbol) = self.source_symbols[i] {
-                self.unpack_sub_blocks(&mut result, symbol, i);
+                self.unpack_sub_blocks(&mut result, symbol.as_bytes(), i);
             } else {
-                let rebuilt = self.rebuild_source_symbol(
-                    &intermediate_symbols,
-                    i as u32,
-                    lt_symbols,
-                    pi_symbols,
-                    sys_index,
-                    p1,
+                let tuple =
+                    intermediate_tuple(i as u32, params.lt_symbols, params.sys_index, params.p1);
+                let mut first = true;
+                enc_indices(
+                    tuple,
+                    params.lt_symbols,
+                    params.pi_symbols,
+                    params.p1,
+                    |j| {
+                        let src = intermediate_symbols[j].as_bytes();
+                        if first {
+                            rebuilt_buf.copy_from_slice(src);
+                            first = false;
+                        } else {
+                            add_assign(&mut rebuilt_buf, src);
+                        }
+                    },
                 );
-                self.unpack_sub_blocks(&mut result, &rebuilt, i);
+                self.unpack_sub_blocks(&mut result, &rebuilt_buf, i);
             }
         }
 
         self.decoded = true;
-        return Some(result);
+        Some(result)
     }
 
     pub fn decode<T: IntoIterator<Item = EncodingPacket>>(
@@ -309,7 +333,7 @@ impl SourceBlockDecoder {
             let mut result =
                 vec![0; self.symbol_size as usize * self.source_block_symbols as usize];
             for (i, symbol) in self.source_symbols.iter().enumerate() {
-                self.unpack_sub_blocks(&mut result, symbol.as_ref().unwrap(), i);
+                self.unpack_sub_blocks(&mut result, symbol.as_ref().unwrap().as_bytes(), i);
             }
 
             self.decoded = true;
@@ -369,18 +393,27 @@ impl SourceBlockDecoder {
             self.decoded = false;
         }
 
-        // Case 3b: standard decode with HDPC rows
+        // Case 3b: standard decode with HDPC rows (slab-backed)
         // See section 5.3.3.4.2. There are S + H zero symbols to start the D vector
-        let mut d = vec![Symbol::zero(self.symbol_size); s + h];
+        let num_padding = (num_extended_symbols - self.source_block_symbols) as usize;
+        let num_repair = self.repair_packets.len();
+        let total = s + h + self.received_source_symbols as usize + num_padding + num_repair;
+        let ss = self.symbol_size as usize;
+        let mut d = SymbolSlab::with_zeros(total, ss);
+        let mut row = s + h;
         for symbol in self.source_symbols.iter().flatten() {
-            d.push(symbol.clone());
+            d.get_mut(row).copy_from_slice(symbol.as_bytes());
+            row += 1;
         }
         for _i in self.source_block_symbols..num_extended_symbols {
-            d.push(Symbol::zero(self.symbol_size));
+            // Padding row already zero
+            row += 1;
         }
         for repair_packet in self.repair_packets.iter() {
-            d.push(Symbol::new(repair_packet.data.clone()));
+            d.get_mut(row).copy_from_slice(&repair_packet.data);
+            row += 1;
         }
+        assert_eq!(row, total);
 
         if num_extended_symbols >= self.sparse_threshold {
             let (constraint_matrix, hdpc) = generate_constraint_matrix::<SparseBinaryMatrix>(
@@ -397,25 +430,36 @@ impl SourceBlockDecoder {
         }
     }
 
-    fn rebuild_source_symbol(
+    fn rebuild_source_symbol_into(
         &self,
-        intermediate_symbols: &[Symbol],
+        dest: &mut [u8],
+        intermediate_symbols: &SymbolSlab,
         source_symbol_id: u32,
-        lt_symbols: u32,
-        pi_symbols: u32,
-        sys_index: u32,
-        p1: u32,
-    ) -> Symbol {
-        let mut rebuilt = Symbol::zero(self.symbol_size);
-        let tuple = intermediate_tuple(source_symbol_id, lt_symbols, sys_index, p1);
-
-        enc_indices(tuple, lt_symbols, pi_symbols, p1, |i| {
-            rebuilt += &intermediate_symbols[i];
-        });
-        rebuilt
+        params: EncodingParameters,
+    ) {
+        let tuple = intermediate_tuple(
+            source_symbol_id,
+            params.lt_symbols,
+            params.sys_index,
+            params.p1,
+        );
+        let mut first = true;
+        enc_indices(
+            tuple,
+            params.lt_symbols,
+            params.pi_symbols,
+            params.p1,
+            |i| {
+                if first {
+                    dest.copy_from_slice(intermediate_symbols.get(i));
+                    first = false;
+                } else {
+                    add_assign(dest, intermediate_symbols.get(i));
+                }
+            },
+        );
     }
 }
-
 #[cfg(feature = "std")]
 #[cfg(test)]
 mod codec_tests {

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -12,10 +12,12 @@ use crate::base::intermediate_tuple;
 use crate::base::partition;
 use crate::constraint_matrix::generate_constraint_matrix;
 use crate::matrix::DenseBinaryMatrix;
+use crate::octets::add_assign;
 use crate::operation_vector::{SymbolOps, perform_op};
 use crate::pi_solver::fused_inverse_mul_symbols;
 use crate::sparse_matrix::SparseBinaryMatrix;
 use crate::symbol::Symbol;
+use crate::symbol_slab::SymbolSlab;
 use crate::systematic_constants::extended_source_block_symbols;
 use crate::systematic_constants::num_hdpc_symbols;
 use crate::systematic_constants::num_intermediate_symbols;
@@ -244,7 +246,7 @@ fn get_or_generate_source_block_encoding_plan(symbol_count: u16) -> Arc<SourceBl
 pub struct SourceBlockEncoder {
     source_block_id: u8,
     source_symbols: Vec<Symbol>,
-    intermediate_symbols: Vec<Symbol>,
+    intermediate_symbols: SymbolSlab,
 }
 
 impl SourceBlockEncoder {
@@ -307,7 +309,7 @@ impl SourceBlockEncoder {
 
         #[cfg(not(feature = "std"))]
         {
-            let (intermediate_symbols, _) = gen_intermediate_symbols(
+            let (intermediate_symbols, _operations) = gen_intermediate_symbols(
                 &source_symbols,
                 config.symbol_size() as usize,
                 SPARSE_MATRIX_THRESHOLD,
@@ -345,14 +347,11 @@ impl SourceBlockEncoder {
     }
 
     pub fn source_packets(&self) -> Vec<EncodingPacket> {
-        let mut esi: i32 = -1;
-        self.source_symbols
-            .iter()
-            .map(|symbol| {
-                esi += 1;
+        (0..self.source_symbols.len())
+            .map(|i| {
                 EncodingPacket::new(
-                    PayloadId::new(self.source_block_id, esi as u32),
-                    symbol.as_bytes().to_vec(),
+                    PayloadId::new(self.source_block_id, i as u32),
+                    self.source_symbols[i].as_bytes().to_vec(),
                 )
             })
             .collect()
@@ -366,19 +365,22 @@ impl SourceBlockEncoder {
         let lt_symbols = num_lt_symbols(self.source_symbols.len() as u32);
         let sys_index = systematic_index(self.source_symbols.len() as u32);
         let p1 = calculate_p1(self.source_symbols.len() as u32);
+        let symbol_size = self.intermediate_symbols.symbol_size();
         for i in 0..packets {
             let tuple = intermediate_tuple(start_encoding_symbol_id + i, lt_symbols, sys_index, p1);
+            let mut data = vec![0u8; symbol_size];
+            enc_into(
+                &mut data,
+                self.source_symbols.len() as u32,
+                &self.intermediate_symbols,
+                tuple,
+            );
             result.push(EncodingPacket::new(
                 PayloadId::new(
                     self.source_block_id,
                     self.source_symbols.len() as u32 + start_repair_symbol_id + i,
                 ),
-                enc(
-                    self.source_symbols.len() as u32,
-                    &self.intermediate_symbols,
-                    tuple,
-                )
-                .into_bytes(),
+                data,
             ));
         }
         result
@@ -389,24 +391,20 @@ impl SourceBlockEncoder {
 fn create_d(
     source_block: &[Symbol],
     symbol_size: usize,
-    extended_source_symbols: usize,
-) -> Vec<Symbol> {
+    _extended_source_symbols: usize,
+) -> SymbolSlab {
     let L = num_intermediate_symbols(source_block.len() as u32);
     let S = num_ldpc_symbols(source_block.len() as u32);
     let H = num_hdpc_symbols(source_block.len() as u32);
 
-    let mut D = Vec::with_capacity(L as usize);
-    for _ in 0..(S + H) {
-        D.push(Symbol::zero(symbol_size));
+    let mut D = SymbolSlab::with_zeros(L as usize, symbol_size);
+    // First S+H entries are zero (already set).
+    // Copy source symbols into positions S+H..
+    for (i, symbol) in source_block.iter().enumerate() {
+        D.get_mut((S + H) as usize + i)
+            .copy_from_slice(symbol.as_bytes());
     }
-    for symbol in source_block {
-        D.push(symbol.clone());
-    }
-    // Extend the source block with padding. See section 5.3.2
-    for _ in 0..(extended_source_symbols - source_block.len()) {
-        D.push(Symbol::zero(symbol_size));
-    }
-    assert_eq!(D.len(), L as usize);
+    // Extended padding symbols stay zero.
     D
 }
 
@@ -416,28 +414,29 @@ fn gen_intermediate_symbols(
     source_block: &[Symbol],
     symbol_size: usize,
     sparse_threshold: u32,
-) -> (Option<Vec<Symbol>>, Option<Vec<SymbolOps>>) {
+) -> (Option<SymbolSlab>, Option<Vec<SymbolOps>>) {
     let extended_source_symbols = extended_source_block_symbols(source_block.len() as u32);
     let D = create_d(source_block, symbol_size, extended_source_symbols as usize);
 
     let indices: Vec<u32> = (0..extended_source_symbols).collect();
-    if extended_source_symbols >= sparse_threshold {
+    let (intermediate_symbols, operations) = if extended_source_symbols >= sparse_threshold {
         let (A, hdpc) =
             generate_constraint_matrix::<SparseBinaryMatrix>(extended_source_symbols, &indices);
-        return fused_inverse_mul_symbols(A, hdpc, D, extended_source_symbols);
+        fused_inverse_mul_symbols(A, hdpc, D, extended_source_symbols)
     } else {
         let (A, hdpc) =
             generate_constraint_matrix::<DenseBinaryMatrix>(extended_source_symbols, &indices);
-        return fused_inverse_mul_symbols(A, hdpc, D, extended_source_symbols);
-    }
-}
+        fused_inverse_mul_symbols(A, hdpc, D, extended_source_symbols)
+    };
 
+    (intermediate_symbols, operations)
+}
 #[allow(non_snake_case)]
 fn gen_intermediate_symbols_with_plan(
     source_block: &[Symbol],
     symbol_size: usize,
     operation_vector: &[SymbolOps],
-) -> Vec<Symbol> {
+) -> SymbolSlab {
     let extended_source_symbols = extended_source_block_symbols(source_block.len() as u32);
     let mut D = create_d(source_block, symbol_size, extended_source_symbols as usize);
 
@@ -447,13 +446,15 @@ fn gen_intermediate_symbols_with_plan(
     D
 }
 
-// Enc[] function, as defined in section 5.3.5.3
+// Allocation-free Enc[] function, as defined in section 5.3.5.3.
+// Writes the encoded symbol directly into `dest`.
 #[allow(clippy::many_single_char_names)]
-fn enc(
+fn enc_into(
+    dest: &mut [u8],
     source_block_symbols: u32,
-    intermediate_symbols: &[Symbol],
+    intermediate_symbols: &SymbolSlab,
     source_tuple: (u32, u32, u32, u32, u32, u32),
-) -> Symbol {
+) {
     let w = num_lt_symbols(source_block_symbols);
     let p = num_pi_symbols(source_block_symbols);
     let p1 = calculate_p1(source_block_symbols);
@@ -465,27 +466,25 @@ fn enc(
     assert!(1 <= a1 && a1 < p1);
     assert!(b1 < p1);
 
-    let mut result = intermediate_symbols[b as usize].clone();
+    dest.copy_from_slice(intermediate_symbols.get(b as usize));
     for _ in 1..d {
         b = (b + a) % w;
-        result += &intermediate_symbols[b as usize];
+        add_assign(dest, intermediate_symbols.get(b as usize));
     }
 
     while b1 >= p {
         b1 = (b1 + a1) % p1;
     }
 
-    result += &intermediate_symbols[(w + b1) as usize];
+    add_assign(dest, intermediate_symbols.get((w + b1) as usize));
 
     for _ in 1..d1 {
         b1 = (b1 + a1) % p1;
         while b1 >= p {
             b1 = (b1 + a1) % p1;
         }
-        result += &intermediate_symbols[(w + b1) as usize];
+        add_assign(dest, intermediate_symbols.get((w + b1) as usize));
     }
-
-    result
 }
 
 #[cfg(feature = "std")]
@@ -552,8 +551,9 @@ mod tests {
         // See section 5.3.3.4.1, item 1.
         for (i, source_symbol) in source_symbols.iter().enumerate() {
             let tuple = intermediate_tuple(i as u32, lt_symbols, sys_index, p1);
-            let encoded = enc(NUM_SYMBOLS, &intermediate_symbols, tuple);
-            assert_eq!(source_symbol, &encoded);
+            let mut encoded = vec![0u8; SYMBOL_SIZE];
+            enc_into(&mut encoded, NUM_SYMBOLS, &intermediate_symbols, tuple);
+            assert_eq!(source_symbol.as_bytes(), &encoded[..]);
         }
     }
 
@@ -578,32 +578,31 @@ mod tests {
         let B = W - S;
 
         // See section 5.3.3.3
-        let mut D = vec![];
-        for i in 0..S {
-            D.push(C[B + i].clone());
-        }
+        // Work with raw byte slices from the slab
+        let ss = C.symbol_size();
+        let mut D: Vec<Vec<u8>> = (0..S).map(|i| C.get(B + i).to_vec()).collect();
 
         for i in 0..B {
             let a = 1 + i / S;
             let b = i % S;
-            D[b] += &C[i];
+            crate::octets::add_assign(&mut D[b], C.get(i));
 
             let b = (b + a) % S;
-            D[b] += &C[i];
+            crate::octets::add_assign(&mut D[b], C.get(i));
 
             let b = (b + a) % S;
-            D[b] += &C[i];
+            crate::octets::add_assign(&mut D[b], C.get(i));
         }
 
         for i in 0..S {
             let a = i % P;
             let b = (i + 1) % P;
-            D[i] += &C[W + a];
-            D[i] += &C[W + b];
+            crate::octets::add_assign(&mut D[i], C.get(W + a));
+            crate::octets::add_assign(&mut D[i], C.get(W + b));
         }
 
         for i in 0..S {
-            assert_eq!(Symbol::zero(SYMBOL_SIZE), D[i]);
+            assert_eq!(vec![0u8; ss], D[i]);
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,6 +36,7 @@ mod rng;
 mod sparse_matrix;
 mod sparse_vec;
 mod symbol;
+mod symbol_slab;
 mod systematic_constants;
 mod util;
 
@@ -74,3 +75,5 @@ pub use crate::pi_solver::IntermediateSymbolDecoder;
 pub use crate::sparse_matrix::SparseBinaryMatrix;
 #[cfg(feature = "benchmarking")]
 pub use crate::symbol::Symbol;
+#[cfg(feature = "benchmarking")]
+pub use crate::symbol_slab::SymbolSlab;

--- a/src/operation_vector.rs
+++ b/src/operation_vector.rs
@@ -5,8 +5,7 @@ use std::vec::Vec;
 use alloc::vec::Vec;
 
 use crate::octet::Octet;
-use crate::symbol::Symbol;
-use crate::util::get_both_indices;
+use crate::symbol_slab::SymbolSlab;
 #[cfg(feature = "serde_support")]
 use serde::{Deserialize, Serialize};
 
@@ -32,29 +31,19 @@ pub enum SymbolOps {
     },
 }
 
-pub fn perform_op(op: &SymbolOps, symbols: &mut Vec<Symbol>) {
+pub fn perform_op(op: &SymbolOps, symbols: &mut SymbolSlab) {
     match op {
         SymbolOps::AddAssign { dest, src } => {
-            let (dest, temp) = get_both_indices(symbols, *dest, *src);
-            *dest += temp;
+            symbols.add_assign(*dest, *src);
         }
         SymbolOps::MulAssign { dest, scalar } => {
-            symbols[*dest].mulassign_scalar(scalar);
+            symbols.mulassign_scalar(*dest, scalar);
         }
         SymbolOps::FMA { dest, src, scalar } => {
-            let (dest, temp) = get_both_indices(symbols, *dest, *src);
-            dest.fused_addassign_mul_scalar(temp, scalar);
+            symbols.fma(*dest, *src, scalar);
         }
         SymbolOps::Reorder { order } => {
-            /* TODO: Reorder is the last step of the algorithm. It should be
-             *       possible to move reorder to be the first step and use when
-             *       creating D (place all rows in correct position before
-             *       calculations). This will however force an update on all
-             *       row-numbers used in all other "Operations". */
-            let mut temp_symbols: Vec<Option<Symbol>> = symbols.drain(..).map(Some).collect();
-            for row_index in order.iter() {
-                symbols.push(temp_symbols[*row_index].take().unwrap());
-            }
+            symbols.set_reorder(order.clone());
         }
     }
 }
@@ -68,153 +57,111 @@ mod tests {
     use crate::octet::Octet;
     use crate::operation_vector::{SymbolOps, perform_op};
     use crate::symbol::Symbol;
+    use crate::symbol_slab::SymbolSlab;
 
     #[test]
     fn test_add() {
-        let rows = 2;
         let symbol_size = 1316;
-        let mut data: Vec<Symbol> = Vec::with_capacity(rows);
-
-        for _i in 0..rows {
-            let mut symbol_data: Vec<u8> = vec![0; symbol_size];
-            for byte in symbol_data.iter_mut().take(symbol_size) {
-                *byte = rand::rng().random();
-            }
-            let symbol = Symbol::new(symbol_data);
-            data.push(symbol);
+        let mut raw0: Vec<u8> = vec![0; symbol_size];
+        let mut raw1: Vec<u8> = vec![0; symbol_size];
+        for b in raw0.iter_mut() {
+            *b = rand::rng().random();
         }
-
-        let mut data0: Vec<u8> = vec![0; symbol_size];
-        let mut data1: Vec<u8> = vec![0; symbol_size];
-        let mut result: Vec<u8> = vec![0; symbol_size];
-        for (i, ((d0, d1), res)) in data0
-            .iter_mut()
-            .zip(data1.iter_mut())
-            .zip(result.iter_mut())
-            .enumerate()
-        {
-            *d0 = data[0].as_bytes()[i];
-            *d1 = data[1].as_bytes()[i];
-            *res = *d0 ^ *d1;
+        for b in raw1.iter_mut() {
+            *b = rand::rng().random();
         }
-        let mut symbol0 = Symbol::new(data0);
-        let symbol1 = Symbol::new(data1);
+        let expected: Vec<u8> = raw0.iter().zip(raw1.iter()).map(|(a, b)| a ^ b).collect();
 
-        symbol0 += &symbol1;
-
-        perform_op(&SymbolOps::AddAssign { dest: 0, src: 1 }, &mut data);
-        assert_eq!(result, data[0].as_bytes());
+        let mut slab =
+            SymbolSlab::from_symbols(vec![Symbol::new(raw0), Symbol::new(raw1)], symbol_size);
+        perform_op(&SymbolOps::AddAssign { dest: 0, src: 1 }, &mut slab);
+        assert_eq!(expected, slab.get(0));
     }
 
     #[test]
     fn test_add_mul() {
-        let rows = 2;
         let symbol_size = 1316;
-        let mut data: Vec<Symbol> = Vec::with_capacity(rows);
-
-        for _i in 0..rows {
-            let mut symbol_data: Vec<u8> = vec![0; symbol_size];
-            for byte in symbol_data.iter_mut().take(symbol_size) {
-                *byte = rand::rng().random();
-            }
-            let symbol = Symbol::new(symbol_data);
-            data.push(symbol);
+        let mut raw0: Vec<u8> = vec![0; symbol_size];
+        let mut raw1: Vec<u8> = vec![0; symbol_size];
+        for b in raw0.iter_mut() {
+            *b = rand::rng().random();
         }
-
+        for b in raw1.iter_mut() {
+            *b = rand::rng().random();
+        }
         let value = 173;
-        let mut data0: Vec<u8> = vec![0; symbol_size];
-        let mut data1: Vec<u8> = vec![0; symbol_size];
-        let mut result: Vec<u8> = vec![0; symbol_size];
-        for (i, ((d0, d1), res)) in data0
-            .iter_mut()
-            .zip(data1.iter_mut())
-            .zip(result.iter_mut())
-            .enumerate()
-        {
-            *d0 = data[0].as_bytes()[i];
-            *d1 = data[1].as_bytes()[i];
-            *res = *d0 ^ (Octet::new(*d1) * Octet::new(value)).byte();
-        }
+        let expected: Vec<u8> = raw0
+            .iter()
+            .zip(raw1.iter())
+            .map(|(d0, d1)| *d0 ^ (Octet::new(*d1) * Octet::new(value)).byte())
+            .collect();
 
+        let mut slab =
+            SymbolSlab::from_symbols(vec![Symbol::new(raw0), Symbol::new(raw1)], symbol_size);
         perform_op(
             &SymbolOps::FMA {
                 dest: 0,
                 src: 1,
                 scalar: Octet::new(value),
             },
-            &mut data,
+            &mut slab,
         );
-        assert_eq!(result, data[0].as_bytes());
+        assert_eq!(expected, slab.get(0));
     }
 
     #[test]
     fn test_mul() {
-        let rows = 1;
         let symbol_size = 1316;
-        let mut data: Vec<Symbol> = Vec::with_capacity(rows);
-
-        for _i in 0..rows {
-            let mut symbol_data: Vec<u8> = vec![0; symbol_size];
-            for byte in symbol_data.iter_mut().take(symbol_size) {
-                *byte = rand::rng().random();
-            }
-            let symbol = Symbol::new(symbol_data);
-            data.push(symbol);
+        let mut raw0: Vec<u8> = vec![0; symbol_size];
+        for b in raw0.iter_mut() {
+            *b = rand::rng().random();
         }
-
         let value = 215;
-        let mut data0: Vec<u8> = vec![0; symbol_size];
-        let mut result: Vec<u8> = vec![0; symbol_size];
-        for (i, (d0, res)) in data0.iter_mut().zip(result.iter_mut()).enumerate() {
-            *d0 = data[0].as_bytes()[i];
-            *res = (Octet::new(*d0) * Octet::new(value)).byte();
-        }
+        let expected: Vec<u8> = raw0
+            .iter()
+            .map(|d0| (Octet::new(*d0) * Octet::new(value)).byte())
+            .collect();
 
+        let mut slab = SymbolSlab::from_symbols(vec![Symbol::new(raw0)], symbol_size);
         perform_op(
             &SymbolOps::MulAssign {
                 dest: 0,
                 scalar: Octet::new(value),
             },
-            &mut data,
+            &mut slab,
         );
-        assert_eq!(result, data[0].as_bytes());
+        assert_eq!(expected, slab.get(0));
     }
 
     #[test]
     fn test_reorder() {
         let rows = 10;
         let symbol_size = 10;
-        let mut data: Vec<Symbol> = Vec::with_capacity(rows);
+        let symbols: Vec<Symbol> = (0..rows)
+            .map(|i| Symbol::new(vec![i as u8; symbol_size]))
+            .collect();
+        let mut slab = SymbolSlab::from_symbols(symbols, symbol_size);
 
-        for i in 0..rows {
-            let mut symbol_data: Vec<u8> = vec![0; symbol_size];
-            for byte in symbol_data.iter_mut().take(symbol_size) {
-                *byte = i as u8;
-            }
-            let symbol = Symbol::new(symbol_data);
-            data.push(symbol);
-        }
-
-        assert_eq!(data[0].as_bytes()[0], 0);
-        assert_eq!(data[1].as_bytes()[0], 1);
-        assert_eq!(data[2].as_bytes()[0], 2);
-        assert_eq!(data[9].as_bytes()[0], 9);
+        assert_eq!(slab.get(0)[0], 0);
+        assert_eq!(slab.get(1)[0], 1);
+        assert_eq!(slab.get(2)[0], 2);
+        assert_eq!(slab.get(9)[0], 9);
 
         perform_op(
             &SymbolOps::Reorder {
                 order: vec![9, 7, 5, 3, 1, 8, 0, 6, 2, 4],
             },
-            &mut data,
+            &mut slab,
         );
-        assert_eq!(data[0].as_bytes()[0], 9);
-        assert_eq!(data[1].as_bytes()[0], 7);
-        assert_eq!(data[2].as_bytes()[0], 5);
-        assert_eq!(data[3].as_bytes()[0], 3);
-        assert_eq!(data[4].as_bytes()[0], 1);
-        assert_eq!(data[5].as_bytes()[0], 8);
-        assert_eq!(data[6].as_bytes()[0], 0);
-        assert_eq!(data[7].as_bytes()[0], 6);
-        assert_eq!(data[8].as_bytes()[0], 2);
-        assert_eq!(data[9].as_bytes()[0], 4);
+        assert_eq!(slab.get(0)[0], 9);
+        assert_eq!(slab.get(1)[0], 7);
+        assert_eq!(slab.get(2)[0], 5);
+        assert_eq!(slab.get(3)[0], 3);
+        assert_eq!(slab.get(4)[0], 1);
+        assert_eq!(slab.get(5)[0], 8);
+        assert_eq!(slab.get(6)[0], 0);
+        assert_eq!(slab.get(7)[0], 6);
+        assert_eq!(slab.get(8)[0], 2);
+        assert_eq!(slab.get(9)[0], 4);
     }
 }

--- a/src/pi_solver.rs
+++ b/src/pi_solver.rs
@@ -16,11 +16,11 @@ use crate::octet_matrix::DenseOctetMatrix;
 use crate::octets::BinaryOctetVec;
 use crate::operation_vector::SymbolOps;
 use crate::symbol::Symbol;
+use crate::symbol_slab::SymbolSlab;
 use crate::systematic_constants::num_hdpc_symbols;
 use crate::systematic_constants::num_intermediate_symbols;
 use crate::systematic_constants::num_ldpc_symbols;
 use crate::systematic_constants::num_pi_symbols;
-use crate::util::get_both_indices;
 
 #[derive(Clone, Debug, PartialEq, PartialOrd, Eq, Ord, Hash)]
 enum RowOp {
@@ -431,7 +431,7 @@ pub struct IntermediateSymbolDecoder<T: BinaryMatrix> {
     // since it's not actually needed
     #[cfg(debug_assertions)]
     X: T,
-    D: Vec<Symbol>,
+    D: SymbolSlab,
     c: Vec<usize>,
     d: Vec<usize>,
     i: usize,
@@ -451,7 +451,7 @@ impl<T: BinaryMatrix> IntermediateSymbolDecoder<T> {
     pub fn new(
         matrix: T,
         hdpc_rows: DenseOctetMatrix,
-        symbols: Vec<Symbol>,
+        symbols: SymbolSlab,
         num_source_symbols: u32,
     ) -> IntermediateSymbolDecoder<T> {
         assert!(matrix.width() <= symbols.len());
@@ -524,6 +524,8 @@ impl<T: BinaryMatrix> IntermediateSymbolDecoder<T> {
     ) -> IntermediateSymbolDecoder<T> {
         assert!(matrix.width() <= symbols.len());
         assert_eq!(matrix.height(), symbols.len());
+        let symbol_size = symbols.first().map(|s| s.as_bytes().len()).unwrap_or(0);
+        let symbols = SymbolSlab::from_symbols(symbols, symbol_size);
         let mut c = Vec::with_capacity(matrix.width());
         let mut d = Vec::with_capacity(symbols.len());
         for i in 0..matrix.width() {
@@ -569,15 +571,13 @@ impl<T: BinaryMatrix> IntermediateSymbolDecoder<T> {
         for op in self.deferred_D_ops.iter() {
             match op {
                 SymbolOps::AddAssign { dest, src } => {
-                    let (dest, temp) = get_both_indices(&mut self.D, *dest, *src);
-                    *dest += temp;
+                    self.D.add_assign(*dest, *src);
                 }
                 SymbolOps::MulAssign { dest, scalar } => {
-                    self.D[*dest].mulassign_scalar(scalar);
+                    self.D.mulassign_scalar(*dest, scalar);
                 }
                 SymbolOps::FMA { dest, src, scalar } => {
-                    let (dest, temp) = get_both_indices(&mut self.D, *dest, *src);
-                    dest.fused_addassign_mul_scalar(temp, scalar);
+                    self.D.fma(*dest, *src, scalar);
                 }
                 SymbolOps::Reorder { order: _order } => {}
             }
@@ -1330,7 +1330,7 @@ impl<T: BinaryMatrix> IntermediateSymbolDecoder<T> {
     }
 
     #[inline(never)]
-    pub fn execute(&mut self) -> (Option<Vec<Symbol>>, Option<Vec<SymbolOps>>) {
+    pub fn execute(&mut self) -> (Option<SymbolSlab>, Option<Vec<SymbolOps>>) {
         #[cfg(debug_assertions)]
         self.X.disable_column_access_acceleration();
 
@@ -1356,24 +1356,17 @@ impl<T: BinaryMatrix> IntermediateSymbolDecoder<T> {
             index_mapping[self.c[i]] = self.d[i];
         }
 
-        #[allow(non_snake_case)]
-        let mut removable_D: Vec<Option<Symbol>> = self.D.drain(..).map(Some).collect();
-
-        let mut result = Vec::with_capacity(self.L);
-        #[allow(clippy::needless_range_loop)]
-        for i in 0..self.L {
-            // push a None so it can be swapped in
-            removable_D.push(None);
-            result.push(removable_D.swap_remove(index_mapping[i]).unwrap());
-        }
-
-        let mut reorder = Vec::with_capacity(self.L);
-        for i in index_mapping.iter().take(self.L) {
-            reorder.push(*i);
-        }
+        // Keep D in-place and return logical reorder mapping.
+        // D.len() may be > L when decoder has overhead symbols.
+        let reorder: Vec<usize> = index_mapping[..self.L].to_vec();
 
         let mut operation_vector = mem::take(&mut self.deferred_D_ops);
-        operation_vector.push(SymbolOps::Reorder { order: reorder });
+        operation_vector.push(SymbolOps::Reorder {
+            order: reorder.clone(),
+        });
+        self.D.set_reorder(reorder);
+        let symbol_size = self.D.symbol_size();
+        let result = mem::replace(&mut self.D, SymbolSlab::with_zeros(0, symbol_size));
         return (Some(result), Some(operation_vector));
     }
 }
@@ -1383,9 +1376,9 @@ impl<T: BinaryMatrix> IntermediateSymbolDecoder<T> {
 pub fn fused_inverse_mul_symbols<T: BinaryMatrix>(
     matrix: T,
     hdpc_rows: DenseOctetMatrix,
-    symbols: Vec<Symbol>,
+    symbols: SymbolSlab,
     num_source_symbols: u32,
-) -> (Option<Vec<Symbol>>, Option<Vec<SymbolOps>>) {
+) -> (Option<SymbolSlab>, Option<Vec<SymbolOps>>) {
     IntermediateSymbolDecoder::new(matrix, hdpc_rows, symbols, num_source_symbols).execute()
 }
 
@@ -1396,7 +1389,16 @@ pub fn fused_inverse_mul_symbols_no_hdpc<T: BinaryMatrix>(
     symbols: Vec<Symbol>,
     num_source_symbols: u32,
 ) -> (Option<Vec<Symbol>>, Option<Vec<SymbolOps>>) {
-    IntermediateSymbolDecoder::new_no_hdpc(matrix, symbols, num_source_symbols).execute()
+    let (slab, ops) =
+        IntermediateSymbolDecoder::new_no_hdpc(matrix, symbols, num_source_symbols).execute();
+    let slab = match slab {
+        Some(s) => s,
+        None => return (None, None),
+    };
+    // execute() now embeds the reorder mapping in the slab, so into_symbols()
+    // returns symbols in the correct logical order.
+    let symbols: Vec<Symbol> = slab.into_symbols();
+    (Some(symbols), ops)
 }
 
 #[cfg(feature = "std")]
@@ -1406,7 +1408,7 @@ mod tests {
     use crate::constraint_matrix::generate_constraint_matrix;
     use crate::matrix::BinaryMatrix;
     use crate::matrix::DenseBinaryMatrix;
-    use crate::symbol::Symbol;
+    use crate::symbol_slab::SymbolSlab;
     use crate::systematic_constants::{
         MAX_SOURCE_SYMBOLS_PER_BLOCK, extended_source_block_symbols, num_ldpc_symbols,
         num_lt_symbols,
@@ -1421,7 +1423,7 @@ mod tests {
             let num_symbols = extended_source_block_symbols(elements);
             let indices: Vec<u32> = (0..num_symbols).collect();
             let (a, hdpc) = generate_constraint_matrix::<DenseBinaryMatrix>(num_symbols, &indices);
-            let symbols = vec![Symbol::zero(1usize); a.width()];
+            let symbols = SymbolSlab::with_zeros(a.width(), 1);
             let mut decoder = IntermediateSymbolDecoder::new(a, hdpc, symbols, num_symbols);
             decoder.execute();
             assert!(

--- a/src/symbol.rs
+++ b/src/symbol.rs
@@ -27,6 +27,7 @@ impl Symbol {
     }
 
     /// Initialize a zeroed symbol, with given size.
+    #[allow(dead_code)]
     pub fn zero<T>(size: T) -> Symbol
     where
         T: Into<usize>,
@@ -53,15 +54,18 @@ impl Symbol {
     }
 
     /// Consume a symbol into a vector of bytes.
+    #[allow(dead_code)]
     pub fn into_bytes(self) -> Vec<u8> {
         self.value
     }
 
+    #[allow(dead_code)]
     #[inline]
     pub fn mulassign_scalar(&mut self, scalar: &Octet) {
         mulassign_scalar(&mut self.value, scalar);
     }
 
+    #[allow(dead_code)]
     #[inline]
     pub fn fused_addassign_mul_scalar(&mut self, other: &Symbol, scalar: &Octet) {
         fused_addassign_mul_scalar(&mut self.value, &other.value, scalar);

--- a/src/symbol_slab.rs
+++ b/src/symbol_slab.rs
@@ -1,0 +1,260 @@
+#[cfg(feature = "std")]
+use std::vec::Vec;
+
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
+
+use crate::octet::Octet;
+use crate::octets::{add_assign, fused_addassign_mul_scalar, mulassign_scalar};
+use crate::symbol::Symbol;
+#[cfg(feature = "serde_support")]
+use serde::{Deserialize, Serialize};
+
+/// Contiguous slab storage for symbols.
+///
+/// Instead of `Vec<Symbol>` (one heap allocation per symbol), this stores all
+/// symbol data in a single `Vec<u8>`. Symbol `i` occupies bytes
+/// `[i * symbol_size .. (i+1) * symbol_size]`.
+///
+/// This gives much better spatial locality for the row operations in the PI
+/// solver, where `AddAssign` / `FMA` ops touch pairs of symbols millions of
+/// times.
+#[derive(Clone, Debug, PartialEq, PartialOrd, Eq, Ord, Hash)]
+#[cfg_attr(feature = "serde_support", derive(Serialize, Deserialize))]
+pub struct SymbolSlab {
+    data: Vec<u8>,
+    count: usize,
+    symbol_size: usize,
+    mapping: Option<Vec<usize>>,
+}
+
+impl SymbolSlab {
+    /// Create a slab with `count` symbols, all zeroed.
+    pub fn with_zeros(count: usize, symbol_size: usize) -> Self {
+        SymbolSlab {
+            data: vec![0u8; count * symbol_size],
+            count,
+            symbol_size,
+            mapping: None,
+        }
+    }
+
+    /// Convert a `Vec<Symbol>` into a contiguous slab.
+    /// All symbols must have the same length.
+    #[allow(dead_code)]
+    pub fn from_symbols(symbols: Vec<Symbol>, symbol_size: usize) -> Self {
+        let count = symbols.len();
+        let mut data = Vec::with_capacity(count * symbol_size);
+        for symbol in symbols {
+            let bytes = symbol.into_bytes();
+            assert_eq!(
+                bytes.len(),
+                symbol_size,
+                "symbol length mismatch in SymbolSlab::from_symbols"
+            );
+            data.extend_from_slice(&bytes);
+        }
+        SymbolSlab {
+            data,
+            count,
+            symbol_size,
+            mapping: None,
+        }
+    }
+
+    /// Convert back to individual `Symbol`s (allocates one `Vec<u8>` per symbol).
+    #[allow(dead_code)]
+    pub fn into_symbols(self) -> Vec<Symbol> {
+        if let Some(ref mapping) = self.mapping {
+            mapping
+                .iter()
+                .map(|&phys| {
+                    let start = phys * self.symbol_size;
+                    Symbol::new(self.data[start..start + self.symbol_size].to_vec())
+                })
+                .collect()
+        } else {
+            self.data
+                .chunks_exact(self.symbol_size)
+                .map(|chunk| Symbol::new(chunk.to_vec()))
+                .collect()
+        }
+    }
+
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.count
+    }
+
+    #[inline]
+    pub fn symbol_size(&self) -> usize {
+        self.symbol_size
+    }
+
+    #[inline(always)]
+    fn physical_index(&self, i: usize) -> usize {
+        self.mapping.as_ref().map_or(i, |m| m[i])
+    }
+
+    /// Borrow symbol `i` as a byte slice.
+    #[inline]
+    pub fn get(&self, i: usize) -> &[u8] {
+        let i = self.physical_index(i);
+        let start = i * self.symbol_size;
+        &self.data[start..start + self.symbol_size]
+    }
+
+    /// Mutably borrow symbol `i` as a byte slice.
+    #[inline]
+    pub fn get_mut(&mut self, i: usize) -> &mut [u8] {
+        let i = self.physical_index(i);
+        let start = i * self.symbol_size;
+        &mut self.data[start..start + self.symbol_size]
+    }
+
+    /// Get mutable access to `dest` and shared access to `src` simultaneously.
+    /// Panics if `dest == src`.
+    #[inline]
+    pub fn get_pair_mut(&mut self, dest: usize, src: usize) -> (&mut [u8], &[u8]) {
+        let dest = self.physical_index(dest);
+        let src = self.physical_index(src);
+        assert_ne!(dest, src, "dest and src must differ");
+        assert!(dest < self.count, "dest out of range");
+        assert!(src < self.count, "src out of range");
+
+        let ss = self.symbol_size;
+        let dest_start = dest * ss;
+        let src_start = src * ss;
+
+        // SAFETY:
+        // - dest/src are in-bounds (asserts above), so both ranges are within self.data.
+        // - dest != src, and every symbol range has length `ss`, so ranges do not overlap.
+        // - we only create one mutable slice (dest) and one shared slice (src).
+        unsafe {
+            let ptr = self.data.as_mut_ptr();
+            let dest_slice = core::slice::from_raw_parts_mut(ptr.add(dest_start), ss);
+            let src_slice = core::slice::from_raw_parts(ptr.add(src_start), ss);
+            (dest_slice, src_slice)
+        }
+    }
+
+    /// `dest[i] += src[i]` (GF(2) XOR)
+    #[inline]
+    pub fn add_assign(&mut self, dest: usize, src: usize) {
+        let (d, s) = self.get_pair_mut(dest, src);
+        add_assign(d, s);
+    }
+
+    /// `dest[i] *= scalar` (GF(256) multiply)
+    #[inline]
+    pub fn mulassign_scalar(&mut self, dest: usize, scalar: &Octet) {
+        let d = self.get_mut(dest);
+        mulassign_scalar(d, scalar);
+    }
+
+    /// `dest[i] += src[i] * scalar` (GF(256) fused multiply-add)
+    #[inline]
+    pub fn fma(&mut self, dest: usize, src: usize, scalar: &Octet) {
+        let (d, s) = self.get_pair_mut(dest, src);
+        fused_addassign_mul_scalar(d, s, scalar);
+    }
+
+    /// Set a virtual reorder mapping: logical index `i` maps to physical index `order[i]`.
+    pub fn set_reorder(&mut self, order: Vec<usize>) {
+        self.mapping = Some(order);
+    }
+
+    /// Bulk copy from a contiguous source block into the slab at the given offset.
+    /// `source` must be `count * symbol_size` bytes.
+    #[allow(dead_code)]
+    pub fn copy_block_from(&mut self, dest_symbol_start: usize, source: &[u8]) {
+        debug_assert!(
+            self.mapping.is_none(),
+            "copy_block_from called with active mapping"
+        );
+        debug_assert_eq!(source.len() % self.symbol_size, 0);
+        let start = dest_symbol_start * self.symbol_size;
+        self.data[start..start + source.len()].copy_from_slice(source);
+    }
+
+    /// Create a new slab by gathering symbols at the given indices from self.
+    /// The new slab has `indices.len()` symbols.
+    #[allow(dead_code)]
+    pub fn gather(&self, indices: &[usize]) -> Self {
+        debug_assert!(self.mapping.is_none(), "gather called with active mapping");
+        let ss = self.symbol_size;
+        let new_count = indices.len();
+        let mut data = vec![0u8; new_count * ss];
+        for (new_pos, &old_pos) in indices.iter().enumerate() {
+            data[new_pos * ss..(new_pos + 1) * ss]
+                .copy_from_slice(&self.data[old_pos * ss..(old_pos + 1) * ss]);
+        }
+        SymbolSlab {
+            data,
+            count: new_count,
+            symbol_size: ss,
+            mapping: None,
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::octet::Octet;
+
+    #[test]
+    fn roundtrip_from_into_symbols() {
+        let symbols = vec![
+            Symbol::new(vec![1, 2, 3, 4]),
+            Symbol::new(vec![5, 6, 7, 8]),
+            Symbol::new(vec![9, 10, 11, 12]),
+        ];
+        let slab = SymbolSlab::from_symbols(symbols.clone(), 4);
+        assert_eq!(slab.len(), 3);
+        assert_eq!(slab.symbol_size(), 4);
+        assert_eq!(slab.get(0), &[1, 2, 3, 4]);
+        assert_eq!(slab.get(1), &[5, 6, 7, 8]);
+        assert_eq!(slab.get(2), &[9, 10, 11, 12]);
+        let back = slab.into_symbols();
+        assert_eq!(back, symbols);
+    }
+
+    #[test]
+    fn add_assign_xor() {
+        let mut slab = SymbolSlab::from_symbols(
+            vec![Symbol::new(vec![0xFF, 0x00]), Symbol::new(vec![0x0F, 0xF0])],
+            2,
+        );
+        slab.add_assign(0, 1);
+        assert_eq!(slab.get(0), &[0xF0, 0xF0]);
+        assert_eq!(slab.get(1), &[0x0F, 0xF0]); // src unchanged
+    }
+
+    #[test]
+    fn reorder_symbols() {
+        let mut slab = SymbolSlab::from_symbols(
+            vec![
+                Symbol::new(vec![0]),
+                Symbol::new(vec![1]),
+                Symbol::new(vec![2]),
+            ],
+            1,
+        );
+        slab.set_reorder(vec![2, 0, 1]);
+        assert_eq!(slab.get(0), &[2]);
+        assert_eq!(slab.get(1), &[0]);
+        assert_eq!(slab.get(2), &[1]);
+    }
+
+    #[test]
+    fn fma_operation() {
+        let mut slab =
+            SymbolSlab::from_symbols(vec![Symbol::new(vec![0x01]), Symbol::new(vec![0x02])], 1);
+        let scalar = Octet::new(3);
+        slab.fma(0, 1, &scalar);
+        // GF(256): 0x01 ^ (0x02 * 3) = 0x01 ^ 0x06 = 0x07
+        assert_eq!(slab.get(0), &[0x07]);
+    }
+}


### PR DESCRIPTION
## Why
- Current hot paths store symbols as `Vec<Symbol>` where each `Symbol` owns an independent `Vec<u8>`.
- At large block sizes this creates many separate allocations and pointer-chasing in row operations.
- Profiling indicated branch/cache/TLB overhead remained significant in encode/decode loops.

## How
This PR keeps the public API intact while switching internal symbol processing to contiguous slab storage:

- Add `SymbolSlab` (`src/symbol_slab.rs`) — one contiguous `Vec<u8>` for all symbol bytes, with an optional embedded reorder mapping so `get(i)` transparently resolves logical-to-physical indices.
- Switch solver state `IntermediateSymbolDecoder::D` to `SymbolSlab`.
- Switch `operation_vector::perform_op` to operate on `SymbolSlab`.
- Switch encoder intermediate-symbol path to slab-backed storage.
- Switch decoder rebuild path to slab-backed storage.
- Keep reorder logical (mapping embedded in `SymbolSlab`) — `set_reorder()` stores the mapping; `get()`/`get_mut()` apply it transparently. No separate `Option<Vec<usize>>` plumbing needed.
- Remove solver execute-time slab clone by moving slab out via `mem::replace`.
- Optimize slab pair access (`get_pair_mut`) for hot GF operations.
- Keep benchmarking helper API usable by exporting `SymbolSlab` under `benchmarking` and updating `matrix_sparsity` bench.
- Integrate cleanly with the no-HDPC decode path (`c37fb14`): the `fused_inverse_mul_symbols_no_hdpc` function converts the slab-backed result back to `Vec<Symbol>` via `into_symbols()` (which respects the embedded mapping), since the no-HDPC solver still uses the `Vec<Symbol>` interface.

## Benchmarks (Zen4, EPYC 9654P, symbol_size=1280)

Rebased on current `origin/master` (includes the HDPC-skip optimization).

### `encode_benchmark` (without pre-built plan)

| K | master (Mbit/s) | this branch (Mbit/s) | Delta |
|---:|---:|---:|---:|
| 10 | 7,699 | 9,481 | **+23.1%** |
| 100 | 10,034 | 13,291 | **+32.5%** |
| 250 | 8,454 | 9,216 | **+9.0%** |
| 500 | 8,230 | 9,031 | **+9.7%** |
| 1,000 | 9,318 | 8,909 | -4.4% |
| 2,000 | 8,607 | 8,125 | -5.6% |
| 5,000 | 6,181 | 7,077 | **+14.5%** |
| 10,000 | 5,517 | 6,829 | **+23.8%** |
| 20,000 | 3,986 | 4,480 | **+12.4%** |
| 50,000 | 2,151 | 2,250 | **+4.6%** |

### `encode_benchmark` (with pre-built plan)

| K | master (Mbit/s) | this branch (Mbit/s) | Delta |
|---:|---:|---:|---:|
| 10 | 7,529 | 6,966 | -7.5% |
| 100 | 10,551 | 13,646 | **+29.3%** |
| 250 | 9,742 | 9,134 | -6.3% |
| 500 | 9,538 | 9,194 | -3.6% |
| 1,000 | 9,318 | 9,068 | -2.7% |
| 2,000 | 8,681 | 8,535 | -1.7% |
| 5,000 | 7,690 | 10,068 | **+30.9%** |
| 10,000 | 6,260 | 6,735 | **+7.6%** |
| 20,000 | 4,883 | 5,991 | **+22.7%** |
| 50,000 | 3,100 | 3,333 | **+7.5%** |

### `decode_benchmark` (0% overhead)

| K | master (Mbit/s) | this branch (Mbit/s) | Delta |
|---:|---:|---:|---:|
| 10 | 2,767 | 2,821 | +1.9% |
| 100 | 3,629 | 4,029 | **+11.0%** |
| 250 | 3,667 | 4,059 | **+10.7%** |
| 500 | 3,766 | 4,018 | **+6.7%** |
| 1,000 | 3,748 | 3,937 | **+5.0%** |
| 2,000 | 3,502 | 3,876 | **+10.7%** |
| 5,000 | 3,202 | 3,223 | +0.7% |
| 10,000 | 2,774 | 2,942 | **+6.0%** |
| 20,000 | 2,156 | 2,195 | +1.8% |
| 50,000 | 1,500 | 1,475 | -1.7% |

### `decode_benchmark` (5% overhead)

With 5% overhead the no-HDPC fast path (`c37fb14`) dominates decode, so the slab optimization has minimal impact on this path. The no-HDPC solver still uses `Vec<Symbol>` internally.

| K | master (Mbit/s) | this branch (Mbit/s) | Delta |
|---:|---:|---:|---:|
| 10 | 2,709 | 3,103 | **+14.5%** |
| 100 | 3,604 | 3,906 | **+8.4%** |
| 250 | 3,860 | 3,761 | -2.6% |
| 500 | 4,639 | 4,639 | +0.0% |
| 1,000 | 4,596 | 4,474 | -2.6% |
| 2,000 | 4,322 | 4,267 | -1.3% |
| 5,000 | 3,785 | 3,830 | +1.2% |
| 10,000 | 3,071 | 3,052 | -0.6% |
| 20,000 | 2,266 | 2,204 | -2.7% |
| 50,000 | 1,462 | 1,349 | -7.7% |

> **Note:** The 5% overhead regression at K=50,000 is attributable to the `Vec<Symbol>` <-> `SymbolSlab` round-trip in `fused_inverse_mul_symbols_no_hdpc`. A follow-up (#211) ports the no-HDPC solver to native slab storage and eliminates this.

## Tests
- `cargo clippy --all --all-targets -- -Dwarnings`
- `cargo test --all` (60 passed, 4 ignored)
- `cargo build --features benchmarking,serde_support`
- `cargo test --features benchmarking`

## Notes
- Rebased on `c37fb14` (perf: skip HDPC rows during decode when overhead is sufficient).
- The reorder mapping is now embedded inside `SymbolSlab` as an `Option<Vec<usize>>` field. `set_reorder()` stores it; `get()`/`get_mut()`/`get_pair_mut()` apply it transparently. Callers (decoder, encoder) no longer need to extract or thread a separate mapping.
