### PR TITLE
perf: reuse scratch buffers for matrix row and column queries

### DIFF
--- a/src/matrix.rs
+++ b/src/matrix.rs
@@ -34,12 +34,28 @@ pub trait BinaryMatrix: Clone {
     // An iterator over rows with a 1-valued entry for the given col
     fn get_ones_in_column(&self, col: usize, start_row: usize, end_row: usize) -> Vec<u32>;
 
+    #[inline]
+    fn get_ones_in_column_into(
+        &self,
+        col: usize,
+        start_row: usize,
+        end_row: usize,
+        out: &mut Vec<u32>,
+    ) {
+        out.clear();
+        out.extend(self.get_ones_in_column(col, start_row, end_row));
+    }
     // Get a slice of columns from a row as Octets
     fn get_sub_row_as_octets(&self, row: usize, start_col: usize) -> BinaryOctetVec;
 
     // Returns a list of columns with non-zero values in the given row, starting with start_col
     fn query_non_zero_columns(&self, row: usize, start_col: usize) -> Vec<usize>;
 
+    #[inline]
+    fn query_non_zero_columns_into(&self, row: usize, start_col: usize, out: &mut Vec<usize>) {
+        out.clear();
+        out.extend(self.query_non_zero_columns(row, start_col));
+    }
     fn get(&self, i: usize, j: usize) -> Octet;
 
     fn swap_rows(&mut self, i: usize, j: usize);
@@ -189,14 +205,25 @@ impl BinaryMatrix for DenseBinaryMatrix {
     }
 
     fn get_ones_in_column(&self, col: usize, start_row: usize, end_row: usize) -> Vec<u32> {
-        let mut rows = vec![];
+        let mut rows = Vec::with_capacity(end_row.saturating_sub(start_row));
+        self.get_ones_in_column_into(col, start_row, end_row, &mut rows);
+        rows
+    }
+
+    fn get_ones_in_column_into(
+        &self,
+        col: usize,
+        start_row: usize,
+        end_row: usize,
+        out: &mut Vec<u32>,
+    ) {
+        out.clear();
+        out.reserve(end_row.saturating_sub(start_row));
         for row in start_row..end_row {
             if self.get(row, col) == Octet::one() {
-                rows.push(row as u32);
+                out.push(row as u32);
             }
         }
-
-        rows
     }
 
     fn get_sub_row_as_octets(&self, row: usize, start_col: usize) -> BinaryOctetVec {
@@ -219,9 +246,19 @@ impl BinaryMatrix for DenseBinaryMatrix {
     }
 
     fn query_non_zero_columns(&self, row: usize, start_col: usize) -> Vec<usize> {
-        (start_col..self.width)
-            .filter(|col| self.get(row, *col) != Octet::zero())
-            .collect()
+        let mut cols = Vec::with_capacity(self.width.saturating_sub(start_col));
+        self.query_non_zero_columns_into(row, start_col, &mut cols);
+        cols
+    }
+
+    fn query_non_zero_columns_into(&self, row: usize, start_col: usize, out: &mut Vec<usize>) {
+        out.clear();
+        out.reserve(self.width.saturating_sub(start_col));
+        for col in start_col..self.width {
+            if self.get(row, col) != Octet::zero() {
+                out.push(col);
+            }
+        }
     }
 
     fn get(&self, i: usize, j: usize) -> Octet {

--- a/src/pi_solver.rs
+++ b/src/pi_solver.rs
@@ -209,8 +209,10 @@ impl FirstPhaseRowSelectionStats {
 
         self.col_graph.remove_node(start_col - 1);
 
+        let mut ones_in_removed_col = Vec::new();
         for col in end_col..self.end_col {
-            for row in matrix.get_ones_in_column(col, self.start_row, end_row) {
+            matrix.get_ones_in_column_into(col, self.start_row, end_row, &mut ones_in_removed_col);
+            for row in ones_in_removed_col.iter().copied() {
                 let row = row as usize;
                 self.ones_per_row.decrement(row);
                 let ones = self.ones_per_row.get(row);
@@ -320,6 +322,7 @@ impl FirstPhaseRowSelectionStats {
         start_row: usize,
         end_row: usize,
         matrix: &T,
+        ones_in_column: &mut Vec<u32>,
     ) -> usize {
         // Find a node (col) in the largest connected component
         let node = self
@@ -327,7 +330,8 @@ impl FirstPhaseRowSelectionStats {
             .get_node_in_largest_connected_component(self.start_col, self.end_col);
 
         // Find a row with two ones in the given column
-        for row in matrix.get_ones_in_column(node, start_row, end_row) {
+        matrix.get_ones_in_column_into(node, start_row, end_row, ones_in_column);
+        for row in ones_in_column.iter().copied() {
             let row = row as usize;
             if self.ones_per_row.get(row) == 2 {
                 return row;
@@ -390,6 +394,7 @@ impl FirstPhaseRowSelectionStats {
         start_row: usize,
         end_row: usize,
         matrix: &T,
+        ones_in_column: &mut Vec<u32>,
     ) -> (Option<usize>, Option<usize>) {
         let mut r = None;
         for i in 1..=(self.end_col - self.start_col) {
@@ -410,7 +415,7 @@ impl FirstPhaseRowSelectionStats {
             // See paragraph starting "If r = 2 and there is a row with exactly 2 ones in V..."
             #[cfg(debug_assertions)]
             self.first_phase_graph_substep_verify(start_row, end_row);
-            let row = self.first_phase_graph_substep(start_row, end_row, matrix);
+            let row = self.first_phase_graph_substep(start_row, end_row, matrix, ones_in_column);
             return (Some(row), r);
         } else {
             let row = self.first_phase_original_degree_substep(start_row, end_row, r.unwrap());
@@ -727,6 +732,8 @@ impl<T: BinaryMatrix> IntermediateSymbolDecoder<T> {
 
         // Record of first phase row operations performed on non-HDPC rows
         let mut row_ops = vec![];
+        let mut row_selection_ones = Vec::new();
+        let mut pivot_column_ones = Vec::new();
 
         while self.i + self.u < self.L {
             // Calculate r
@@ -737,6 +744,7 @@ impl<T: BinaryMatrix> IntermediateSymbolDecoder<T> {
                 self.i,
                 self.A.height() - num_hdpc_rows,
                 &self.A,
+                &mut row_selection_ones,
             );
 
             r?;
@@ -763,15 +771,18 @@ impl<T: BinaryMatrix> IntermediateSymbolDecoder<T> {
             // because of Errata 2.
             let temp_value = self.A.get(temp, temp);
 
-            let ones_in_column =
-                self.A
-                    .get_ones_in_column(temp, self.i + 1, self.A.height() - num_hdpc_rows);
+            self.A.get_ones_in_column_into(
+                temp,
+                self.i + 1,
+                self.A.height() - num_hdpc_rows,
+                &mut pivot_column_ones,
+            );
             selection_helper.resize(
                 self.i + 1,
                 self.A.height() - num_hdpc_rows,
                 self.i + 1,
                 self.A.width() - self.u - (r - 1),
-                &ones_in_column,
+                &pivot_column_ones,
                 &self.A,
             );
             for i in 0..(r - 1) {
@@ -780,7 +791,7 @@ impl<T: BinaryMatrix> IntermediateSymbolDecoder<T> {
             }
 
             // Skip the first element since that's the i'th row
-            for row in ones_in_column {
+            for row in pivot_column_ones.iter().copied() {
                 let row = row as usize;
                 assert_eq!(&temp_value, &Octet::one());
                 // Addition is equivalent to subtraction.
@@ -1000,8 +1011,11 @@ impl<T: BinaryMatrix> IntermediateSymbolDecoder<T> {
     #[allow(non_snake_case)]
     #[inline(never)]
     fn fourth_phase(&mut self) {
+        let mut non_zero_columns = Vec::new();
         for i in 0..self.i {
-            for j in self.A.query_non_zero_columns(i, self.i) {
+            self.A
+                .query_non_zero_columns_into(i, self.i, &mut non_zero_columns);
+            for j in non_zero_columns.iter().copied() {
                 #[cfg(debug_assertions)]
                 self.fma_rows(j, i, Octet::one(), 0);
                 // Skip applying to cols before i due to Errata 11

--- a/src/sparse_matrix.rs
+++ b/src/sparse_matrix.rs
@@ -202,11 +202,18 @@ impl BinaryMatrix for SparseBinaryMatrix {
     }
 
     fn query_non_zero_columns(&self, row: usize, start_col: usize) -> Vec<usize> {
+        let mut result = Vec::with_capacity(self.num_dense_columns);
+        self.query_non_zero_columns_into(row, start_col, &mut result);
+        result
+    }
+
+    fn query_non_zero_columns_into(&self, row: usize, start_col: usize, out: &mut Vec<usize>) {
         // The following implementation is equivalent to .filter(|x| self.get(row, x) != Octet::zero())
         // but this implementation optimizes for sequential access and avoids all the
         // extra bit index math
         assert_eq!(start_col, self.width - self.num_dense_columns);
-        let mut result = vec![];
+        out.clear();
+        out.reserve(self.num_dense_columns);
         let physical_row = self.logical_row_to_physical[row] as usize;
         let (mut word, bit) =
             self.bit_position(physical_row, self.logical_col_to_dense_col(start_col));
@@ -216,7 +223,7 @@ impl BinaryMatrix for SparseBinaryMatrix {
         // must be the column we're looking for, so they're no need to zero out columns left of it.
         let mut block = self.dense_elements[word];
         while block.trailing_zeros() < WORD_WIDTH as u32 {
-            result.push(col + block.trailing_zeros() as usize - bit);
+            out.push(col + block.trailing_zeros() as usize - bit);
             block &= !(SparseBinaryMatrix::select_mask(block.trailing_zeros() as usize));
         }
         col += WORD_WIDTH - bit;
@@ -226,14 +233,12 @@ impl BinaryMatrix for SparseBinaryMatrix {
             let mut block = self.dense_elements[word];
             // process the whole word in one shot to improve efficiency
             while block.trailing_zeros() < WORD_WIDTH as u32 {
-                result.push(col + block.trailing_zeros() as usize);
+                out.push(col + block.trailing_zeros() as usize);
                 block &= !(SparseBinaryMatrix::select_mask(block.trailing_zeros() as usize));
             }
             col += WORD_WIDTH;
             word += 1;
         }
-
-        result
     }
 
     fn get(&self, i: usize, j: usize) -> Octet {
@@ -270,11 +275,24 @@ impl BinaryMatrix for SparseBinaryMatrix {
     }
 
     fn get_ones_in_column(&self, col: usize, start_row: usize, end_row: usize) -> Vec<u32> {
+        let mut rows = Vec::with_capacity(end_row.saturating_sub(start_row));
+        self.get_ones_in_column_into(col, start_row, end_row, &mut rows);
+        rows
+    }
+
+    fn get_ones_in_column_into(
+        &self,
+        col: usize,
+        start_row: usize,
+        end_row: usize,
+        out: &mut Vec<u32>,
+    ) {
         assert!(!self.column_index_disabled);
         #[cfg(debug_assertions)]
         debug_assert!(self.debug_indexed_column_valid[col]);
         let physical_col = self.logical_col_to_physical[col];
-        let mut rows = vec![];
+        out.clear();
+        out.reserve(end_row.saturating_sub(start_row));
         for physical_row in self
             .sparse_columnar_values
             .as_ref()
@@ -283,11 +301,9 @@ impl BinaryMatrix for SparseBinaryMatrix {
         {
             let logical_row = self.physical_row_to_logical[*physical_row as usize];
             if start_row <= logical_row as usize && logical_row < end_row as u32 {
-                rows.push(logical_row);
+                out.push(logical_row);
             }
         }
-
-        rows
     }
 
     fn swap_rows(&mut self, i: usize, j: usize) {


### PR DESCRIPTION
## Why
- Reduce transient allocations and repeated setup work in matrix row/column query paths used by first-phase PI solving.
- Improve hot-path throughput without changing decoding/encoding behavior.

## How
- Reuse scratch buffers instead of rebuilding temporary vectors in matrix/sparse-matrix row/column queries.
- Thread scratch-space through call sites in `pi_solver` so first-phase stats can reuse memory across iterations.
- Keep algorithmic behavior unchanged; this is strictly a memory-reuse optimization.

## Benchmarks 
- decode 0%: **-1.82%**
- decode 5%: **+3.86%**
- encode (no pre-plan): **+2.76%**
- encode (pre-built plan): **+7.99%**

## Tests
- `cargo check --lib`
- `RUSTFLAGS="-D warnings" cargo check --lib`
- `cargo test --all`
