### PR TITLE
perf: use native SymbolSlab in no-HDPC decode path

### DIFF
--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -246,7 +246,7 @@ impl SourceBlockDecoder {
     fn try_pi_decode_no_hdpc(
         &mut self,
         constraint_matrix: impl BinaryMatrix,
-        symbols: Vec<Symbol>,
+        symbols: SymbolSlab,
     ) -> Option<Vec<u8>> {
         let intermediate_symbols = match fused_inverse_mul_symbols_no_hdpc(
             constraint_matrix,
@@ -269,23 +269,11 @@ impl SourceBlockDecoder {
             if let Some(ref symbol) = self.source_symbols[i] {
                 self.unpack_sub_blocks(&mut result, symbol.as_bytes(), i);
             } else {
-                let tuple =
-                    intermediate_tuple(i as u32, params.lt_symbols, params.sys_index, params.p1);
-                let mut first = true;
-                enc_indices(
-                    tuple,
-                    params.lt_symbols,
-                    params.pi_symbols,
-                    params.p1,
-                    |j| {
-                        let src = intermediate_symbols[j].as_bytes();
-                        if first {
-                            rebuilt_buf.copy_from_slice(src);
-                            first = false;
-                        } else {
-                            add_assign(&mut rebuilt_buf, src);
-                        }
-                    },
+                self.rebuild_source_symbol_into(
+                    &mut rebuilt_buf,
+                    &intermediate_symbols,
+                    i as u32,
+                    params,
                 );
                 self.unpack_sub_blocks(&mut result, &rebuilt_buf, i);
             }
@@ -361,17 +349,27 @@ impl SourceBlockDecoder {
         // Case 3a: try to solve without HDPC rows (pure GF(2)) when we have enough overhead.
         // This avoids expensive GF(256) operations in the solver.
         // We need at least L total rows: S LDPC + encoded >= L, i.e. encoded >= K' + H.
+        let num_padding = (num_extended_symbols - self.source_block_symbols) as usize;
+        let num_repair = self.repair_packets.len();
+        let ss = self.symbol_size as usize;
         if s + encoded_isis.len() >= l {
-            let mut d_no_hdpc = vec![Symbol::zero(self.symbol_size); s];
+            let total_no_hdpc =
+                s + self.received_source_symbols as usize + num_padding + num_repair;
+            let mut d_no_hdpc = SymbolSlab::with_zeros(total_no_hdpc, ss);
+            let mut row = s;
             for symbol in self.source_symbols.iter().flatten() {
-                d_no_hdpc.push(symbol.clone());
+                d_no_hdpc.get_mut(row).copy_from_slice(symbol.as_bytes());
+                row += 1;
             }
             for _i in self.source_block_symbols..num_extended_symbols {
-                d_no_hdpc.push(Symbol::zero(self.symbol_size));
+                // Padding row already zero
+                row += 1;
             }
             for repair_packet in self.repair_packets.iter() {
-                d_no_hdpc.push(Symbol::new(repair_packet.data.clone()));
+                d_no_hdpc.get_mut(row).copy_from_slice(&repair_packet.data);
+                row += 1;
             }
+            assert_eq!(row, total_no_hdpc);
 
             let result = if num_extended_symbols >= self.sparse_threshold {
                 let matrix = generate_constraint_matrix_no_hdpc::<SparseBinaryMatrix>(
@@ -395,10 +393,7 @@ impl SourceBlockDecoder {
 
         // Case 3b: standard decode with HDPC rows (slab-backed)
         // See section 5.3.3.4.2. There are S + H zero symbols to start the D vector
-        let num_padding = (num_extended_symbols - self.source_block_symbols) as usize;
-        let num_repair = self.repair_packets.len();
         let total = s + h + self.received_source_symbols as usize + num_padding + num_repair;
-        let ss = self.symbol_size as usize;
         let mut d = SymbolSlab::with_zeros(total, ss);
         let mut row = s + h;
         for symbol in self.source_symbols.iter().flatten() {

--- a/src/pi_solver.rs
+++ b/src/pi_solver.rs
@@ -15,7 +15,6 @@ use crate::octet::Octet;
 use crate::octet_matrix::DenseOctetMatrix;
 use crate::octets::BinaryOctetVec;
 use crate::operation_vector::SymbolOps;
-use crate::symbol::Symbol;
 use crate::symbol_slab::SymbolSlab;
 use crate::systematic_constants::num_hdpc_symbols;
 use crate::systematic_constants::num_intermediate_symbols;
@@ -519,13 +518,11 @@ impl<T: BinaryMatrix> IntermediateSymbolDecoder<T> {
     /// The constraint matrix must NOT contain HDPC rows (G_ENC starts at row S).
     pub fn new_no_hdpc(
         matrix: T,
-        symbols: Vec<Symbol>,
+        symbols: SymbolSlab,
         num_source_symbols: u32,
     ) -> IntermediateSymbolDecoder<T> {
         assert!(matrix.width() <= symbols.len());
         assert_eq!(matrix.height(), symbols.len());
-        let symbol_size = symbols.first().map(|s| s.as_bytes().len()).unwrap_or(0);
-        let symbols = SymbolSlab::from_symbols(symbols, symbol_size);
         let mut c = Vec::with_capacity(matrix.width());
         let mut d = Vec::with_capacity(symbols.len());
         for i in 0..matrix.width() {
@@ -1386,19 +1383,10 @@ pub fn fused_inverse_mul_symbols<T: BinaryMatrix>(
 // Used during decoding with sufficient overhead to solve in GF(2) only.
 pub fn fused_inverse_mul_symbols_no_hdpc<T: BinaryMatrix>(
     matrix: T,
-    symbols: Vec<Symbol>,
+    symbols: SymbolSlab,
     num_source_symbols: u32,
-) -> (Option<Vec<Symbol>>, Option<Vec<SymbolOps>>) {
-    let (slab, ops) =
-        IntermediateSymbolDecoder::new_no_hdpc(matrix, symbols, num_source_symbols).execute();
-    let slab = match slab {
-        Some(s) => s,
-        None => return (None, None),
-    };
-    // execute() now embeds the reorder mapping in the slab, so into_symbols()
-    // returns symbols in the correct logical order.
-    let symbols: Vec<Symbol> = slab.into_symbols();
-    (Some(symbols), ops)
+) -> (Option<SymbolSlab>, Option<Vec<SymbolOps>>) {
+    IntermediateSymbolDecoder::new_no_hdpc(matrix, symbols, num_source_symbols).execute()
 }
 
 #[cfg(feature = "std")]


### PR DESCRIPTION
> **Depends on #208** — please review/merge that first. This PR adds a single commit on top.

## Why
PR #208 moved the main encoder/decoder hot path to contiguous `SymbolSlab` storage, but left the no-HDPC decode fast path on a `Vec<Symbol>` bridge that converts `Vec<Symbol> -> SymbolSlab` on entry and `SymbolSlab -> Vec<Symbol>` on exit around the solver.

At 5% overhead, decode is dominated by the no-HDPC path, so that bridge left measurable throughput on the table.

## How
- Build Case 3a decoder input directly as `SymbolSlab` (no more `Symbol::clone()` / `Symbol::zero()` per row).
- Change `try_pi_decode_no_hdpc` to take `SymbolSlab` and reuse `rebuild_source_symbol_into(...)`, matching the standard HDPC path.
- Change `IntermediateSymbolDecoder::new_no_hdpc` and `fused_inverse_mul_symbols_no_hdpc` to take/return `SymbolSlab` directly.
- Delete the temporary `Vec<Symbol>` conversion and reorder-gather bridge.

Only 2 files changed.

## Benchmarks (vs parent branch `perf/symbol-slab-pr`)
Zen4, EPYC 9654P, symbol_size=1280.

### `decode_benchmark` (5% overhead) — primary target
| K | parent (Mbit/s) | this branch (Mbit/s) | Delta |
|---:|---:|---:|---:|
| 10 | 3,103 | 3,093 | -0.3% |
| 100 | 3,906 | 3,877 | -0.8% |
| 250 | 3,761 | 3,950 | **+5.0%** |
| 500 | 4,639 | 4,978 | **+7.3%** |
| 1,000 | 4,474 | 4,930 | **+10.2%** |
| 2,000 | 4,267 | 4,617 | **+8.2%** |
| 5,000 | 3,830 | 4,019 | **+4.9%** |
| 10,000 | 3,052 | 3,538 | **+15.9%** |
| 20,000 | 2,204 | 2,151 | -2.4% |
| 50,000 | 1,349 | 1,434 | **+6.3%** |

### `decode_benchmark` (0% overhead) — secondary
| K | parent (Mbit/s) | this branch (Mbit/s) | Delta |
|---:|---:|---:|---:|
| 10 | 2,821 | 2,798 | -0.8% |
| 100 | 4,029 | 4,014 | -0.4% |
| 250 | 4,059 | 4,043 | -0.4% |
| 500 | 4,018 | 4,002 | -0.4% |
| 1,000 | 3,937 | 3,952 | +0.4% |
| 2,000 | 3,876 | 3,876 | +0.0% |
| 5,000 | 3,223 | 3,288 | **+2.0%** |
| 10,000 | 2,942 | 2,898 | -1.5% |
| 20,000 | 2,195 | 2,123 | -3.3% |
| 50,000 | 1,475 | 1,458 | -1.2% |

Expected shape: biggest gains on the no-HDPC-heavy 5% overhead path at medium-large K. The 0% overhead path is unchanged (standard solver, not touched by this PR).

### `encode_benchmark` — unchanged (no encoder changes in this PR)

## Tests
- `cargo clippy --all --all-targets -- -Dwarnings`
- `cargo test --all` (60 passed, 4 ignored)
- `cargo build --features benchmarking,serde_support`
- `cargo test --features benchmarking`
