### PR TITLE
Update rand crate to 0.10.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ pyo3 = {version = "0.24.1", features=["extension-module", "abi3-py37"], optional
 [dev-dependencies]
 criterion = "0.5"
 primal = "0.3"
-rand = "0.9.3"
+rand = "0.10.1"
 threadpool = "1.7"
 
 [[bench]]

--- a/benches/codec_benchmark.rs
+++ b/benches/codec_benchmark.rs
@@ -4,7 +4,7 @@ use criterion::Throughput;
 use criterion::criterion_group;
 use criterion::criterion_main;
 
-use rand::Rng;
+use rand::RngExt;
 use raptorq::SourceBlockDecoder;
 use raptorq::SourceBlockEncoder;
 use raptorq::Symbol;

--- a/benches/decode_benchmark.rs
+++ b/benches/decode_benchmark.rs
@@ -1,4 +1,4 @@
-use rand::Rng;
+use rand::RngExt;
 use raptorq::{ObjectTransmissionInformation, SourceBlockDecoder, SourceBlockEncoder};
 use std::time::Instant;
 

--- a/benches/encode_benchmark.rs
+++ b/benches/encode_benchmark.rs
@@ -1,4 +1,4 @@
-use rand::Rng;
+use rand::RngExt;
 use raptorq::{ObjectTransmissionInformation, SourceBlockEncoder, SourceBlockEncodingPlan};
 use std::time::Instant;
 

--- a/benches/roundtrip_benchmark.rs
+++ b/benches/roundtrip_benchmark.rs
@@ -1,5 +1,5 @@
 use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
-use rand::Rng;
+use rand::RngExt;
 use raptorq::{
     ObjectTransmissionInformation, SourceBlockDecoder, SourceBlockEncoder, SourceBlockEncodingPlan,
 };

--- a/examples/main.rs
+++ b/examples/main.rs
@@ -2,7 +2,7 @@
 use rand::seq::SliceRandom;
 
 #[cfg(not(feature = "python"))]
-use rand::Rng;
+use rand::RngExt;
 
 #[cfg(not(feature = "python"))]
 use raptorq::{Decoder, Encoder, EncodingPacket};

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -11,7 +11,7 @@ cargo-fuzz = true
 [dependencies]
 arbitrary = { version = "1.1.0", features = ["derive"] }
 libfuzzer-sys = { version = "0.4.0", features = ["arbitrary-derive"] }
-rand = "0.8.5"
+rand = "0.10.1"
 
 [dependencies.raptorq]
 path = ".."

--- a/fuzz/fuzz_targets/fuzz_raptorq.rs
+++ b/fuzz/fuzz_targets/fuzz_raptorq.rs
@@ -3,7 +3,7 @@
 use arbitrary::Unstructured;
 use libfuzzer_sys::arbitrary::Arbitrary;
 use libfuzzer_sys::fuzz_target;
-use rand::Rng;
+use rand::RngExt;
 use rand::prelude::*;
 use raptorq::{Decoder, EncodingPacket, Encoder};
 use std::mem::size_of;
@@ -63,7 +63,7 @@ fuzz_target!(|config: FuzzConfig| {
     // Generate some random data to send
     let mut data: Vec<u8> = vec![0; len];
     for i in 0..data.len() {
-        data[i] = rng.gen();
+        data[i] = rng.random();
     }
 
     let encoder = Encoder::with_defaults(&data, config.max_packet_size.value);

--- a/src/base.rs
+++ b/src/base.rs
@@ -329,7 +329,7 @@ pub fn intermediate_tuple(
 #[cfg(test)]
 mod tests {
     use crate::{EncodingPacket, ObjectTransmissionInformation, PayloadId};
-    use rand::Rng;
+    use rand::RngExt;
 
     #[test]
     fn max_transfer_size() {

--- a/src/constraint_matrix.rs
+++ b/src/constraint_matrix.rs
@@ -241,7 +241,7 @@ mod tests {
     use crate::systematic_constants::{
         extended_source_block_symbols, num_hdpc_symbols, num_ldpc_symbols,
     };
-    use rand::Rng;
+    use rand::RngExt;
     use std::vec::Vec;
 
     #[allow(non_snake_case)]

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -467,7 +467,7 @@ mod codec_tests {
         vec::Vec,
     };
 
-    use rand::Rng;
+    use rand::RngExt;
     #[cfg(not(feature = "python"))]
     use rand::seq::SliceRandom;
 

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -486,7 +486,7 @@ fn enc_into(
 #[cfg(feature = "std")]
 #[cfg(test)]
 mod tests {
-    use rand::Rng;
+    use rand::RngExt;
     use std::vec::Vec;
 
     use super::*;

--- a/src/matrix.rs
+++ b/src/matrix.rs
@@ -352,7 +352,7 @@ impl BinaryMatrix for DenseBinaryMatrix {
 
 #[cfg(test)]
 mod tests {
-    use rand::Rng;
+    use rand::RngExt;
 
     use crate::matrix::{BinaryMatrix, DenseBinaryMatrix};
     use crate::octet::Octet;

--- a/src/octet.rs
+++ b/src/octet.rs
@@ -290,7 +290,7 @@ impl<'b> Div<&'b Octet> for &Octet {
 
 #[cfg(test)]
 mod tests {
-    use rand::Rng;
+    use rand::RngExt;
 
     use crate::octet::OCT_EXP;
     use crate::octet::OCT_LOG;

--- a/src/octets.rs
+++ b/src/octets.rs
@@ -1098,7 +1098,7 @@ pub fn add_assign(octets: &mut [u8], other: &[u8]) {
 #[cfg(feature = "std")]
 #[cfg(test)]
 mod tests {
-    use rand::Rng;
+    use rand::RngExt;
     use std::vec::Vec;
 
     use crate::octet::Octet;

--- a/src/operation_vector.rs
+++ b/src/operation_vector.rs
@@ -51,7 +51,7 @@ pub fn perform_op(op: &SymbolOps, symbols: &mut SymbolSlab) {
 #[cfg(feature = "std")]
 #[cfg(test)]
 mod tests {
-    use rand::Rng;
+    use rand::RngExt;
     use std::vec::Vec;
 
     use crate::octet::Octet;

--- a/src/symbol.rs
+++ b/src/symbol.rs
@@ -82,7 +82,7 @@ impl<'a> AddAssign<&'a Symbol> for Symbol {
 #[cfg(feature = "std")]
 #[cfg(test)]
 mod tests {
-    use rand::Rng;
+    use rand::RngExt;
     use std::vec::Vec;
 
     use crate::symbol::Symbol;


### PR DESCRIPTION
## Summary
This PR updates the rand crate dependency to version 0.10.1 and migrates the codebase to use the `RngExt` trait instead of the `Rng` trait, along with updating the method call from `gen()` to `random()`.

## Key Changes
- Updated `rand` dependency from 0.8.5/0.9.3 to 0.10.1 in both main `Cargo.toml` and `fuzz/Cargo.toml`
- Replaced all imports of `use rand::Rng` with `use rand::RngExt` across the codebase
- Updated the random number generation method call from `rng.gen()` to `rng.random()` in `fuzz/fuzz_targets/fuzz_raptorq.rs`

## Files Modified
- Cargo.toml and fuzz/Cargo.toml: Dependency version updates
- fuzz/fuzz_targets/fuzz_raptorq.rs: Import and method call updates
- benches/*.rs: Import updates across all benchmark files
- examples/main.rs: Import update
- src/*.rs: Import updates across all source modules (base.rs, constraint_matrix.rs, decoder.rs, encoder.rs, matrix.rs, octet.rs, octets.rs, operation_vector.rs, symbol.rs)

## Implementation Details
The changes align with the rand 0.10.x API where `RngExt` is the trait that provides the `random()` method for generating random values. This is a straightforward migration to the newer rand API without any functional changes to the core logic.

https://claude.ai/code/session_01HMMbbcU6RFTH5BC7RLqNXn