### PR TITLE
perf: reuse calculations and avoid temp allocs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ crate-type = ["lib"]
 [dependencies]
 serde = {version = "1.0.102", features=["std", "derive"], optional = true}
 pyo3 = {version = "0.24.1", features=["extension-module", "abi3-py37"], optional = true }
+likely_polyfill = "1.0.0"
 
 [dev-dependencies]
 criterion = "0.5"

--- a/benches/matrix_sparsity.rs
+++ b/benches/matrix_sparsity.rs
@@ -2,13 +2,15 @@ use raptorq::IntermediateSymbolDecoder;
 use raptorq::Octet;
 use raptorq::SymbolSlab;
 use raptorq::generate_constraint_matrix;
-use raptorq::{BinaryMatrix, SparseBinaryMatrix, extended_source_block_symbols};
+use raptorq::{
+    BinaryMatrix, SparseBinaryMatrix, extended_source_block_symbols, num_intermediate_symbols,
+};
 
 fn main() {
     for elements in [10, 100, 1000, 10000, 40000, 56403].iter() {
         let num_symbols = extended_source_block_symbols(*elements);
-        let indices: Vec<u32> = (0..num_symbols).collect();
-        let (a, hdpc) = generate_constraint_matrix::<SparseBinaryMatrix>(num_symbols, &indices);
+        let (a, hdpc) =
+            generate_constraint_matrix::<SparseBinaryMatrix>(num_symbols, 0..num_symbols);
         let mut density = 0;
         let mut row_density = vec![0; a.height()];
         for i in 0..a.height() {
@@ -56,7 +58,13 @@ fn main() {
         );
 
         let symbols = SymbolSlab::with_zeros(a.width(), 1);
-        let mut decoder = IntermediateSymbolDecoder::new(a, hdpc, symbols, num_symbols);
+        let mut decoder = IntermediateSymbolDecoder::new(
+            a,
+            hdpc,
+            symbols,
+            num_symbols,
+            num_intermediate_symbols(num_symbols),
+        );
         println!(
             "Initial memory usage: {}KB",
             decoder.get_non_symbol_bytes() / 1024

--- a/src/constraint_matrix.rs
+++ b/src/constraint_matrix.rs
@@ -115,7 +115,7 @@ fn generate_hdpc_rows(Kprime: usize, S: usize, H: usize) -> DenseOctetMatrix {
 #[allow(non_snake_case)]
 pub fn generate_constraint_matrix<T: BinaryMatrix>(
     source_block_symbols: u32,
-    encoded_symbol_indices: &[u32],
+    encoded_symbol_indices: impl ExactSizeIterator<Item = u32>,
 ) -> (T, DenseOctetMatrix) {
     let Kprime = extended_source_block_symbols(source_block_symbols) as usize;
     let S = num_ldpc_symbols(source_block_symbols) as usize;
@@ -160,7 +160,7 @@ pub fn generate_constraint_matrix<T: BinaryMatrix>(
     let pi_symbols = num_pi_symbols(Kprime as u32);
     let sys_index = systematic_index(Kprime as u32);
     let p1 = calculate_p1(Kprime as u32);
-    for (row, &i) in encoded_symbol_indices.iter().enumerate() {
+    for (row, i) in encoded_symbol_indices.enumerate() {
         // row != i, because i is the ESI
         let tuple = intermediate_tuple(i, lt_symbols, sys_index, p1);
 

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -139,9 +139,21 @@ pub struct SourceBlockDecoder {
     received_esi: Set<u32>,
     decoded: bool,
     sparse_threshold: u32,
+
+    #[cfg_attr(feature = "serde_support", serde(default, skip))]
+    computed_set: bool,
+    #[cfg_attr(feature = "serde_support", serde(default, skip))]
+    computed: SourceBlockDecoderComputed,
 }
 
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
+struct SourceBlockDecoderComputed {
+    num_intermediate_symbols: u32,
+    params: EncodingParameters,
+}
+
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
+#[cfg_attr(feature = "serde_support", derive(Serialize, Deserialize))]
 struct EncodingParameters {
     lt_symbols: u32,
     pi_symbols: u32,
@@ -168,12 +180,29 @@ impl SourceBlockDecoder {
             received_esi: Set::new(),
             decoded: false,
             sparse_threshold: SPARSE_MATRIX_THRESHOLD,
+            computed_set: false,
+            computed: Default::default(),
         }
     }
 
     #[cfg(any(test, feature = "benchmarking"))]
     pub fn set_sparse_threshold(&mut self, value: u32) {
         self.sparse_threshold = value;
+    }
+
+    fn computed(&mut self) -> SourceBlockDecoderComputed {
+        if !self.computed_set {
+            self.computed_set = true;
+            self.computed.num_intermediate_symbols =
+                num_intermediate_symbols(self.source_block_symbols);
+            self.computed.params = EncodingParameters {
+                lt_symbols: num_lt_symbols(self.source_block_symbols),
+                pi_symbols: num_pi_symbols(self.source_block_symbols),
+                sys_index: systematic_index(self.source_block_symbols),
+                p1: calculate_p1(self.source_block_symbols),
+            };
+        }
+        self.computed
     }
 
     fn unpack_sub_blocks(&self, result: &mut [u8], symbol: &[u8], symbol_index: usize) {
@@ -204,23 +233,16 @@ impl SourceBlockDecoder {
         hdpc_rows: DenseOctetMatrix,
         symbols: SymbolSlab,
     ) -> Option<Vec<u8>> {
-        let intermediate_symbols = match fused_inverse_mul_symbols(
+        let computed = self.computed();
+        let intermediate_symbols = fused_inverse_mul_symbols(
             constraint_matrix,
             hdpc_rows,
             symbols,
             self.source_block_symbols,
-        ) {
-            (None, _) => return None,
-            (Some(s), _) => s,
-        };
+            computed.num_intermediate_symbols,
+        )?;
 
         let mut result = vec![0; self.symbol_size as usize * self.source_block_symbols as usize];
-        let params = EncodingParameters {
-            lt_symbols: num_lt_symbols(self.source_block_symbols),
-            pi_symbols: num_pi_symbols(self.source_block_symbols),
-            sys_index: systematic_index(self.source_block_symbols),
-            p1: calculate_p1(self.source_block_symbols),
-        };
         let ss = self.symbol_size as usize;
         let mut rebuilt_buf = vec![0u8; ss];
         for i in 0..self.source_block_symbols as usize {
@@ -231,7 +253,7 @@ impl SourceBlockDecoder {
                     &mut rebuilt_buf,
                     &intermediate_symbols,
                     i as u32,
-                    params,
+                    computed.params,
                 );
                 self.unpack_sub_blocks(&mut result, &rebuilt_buf, i);
             }
@@ -248,22 +270,15 @@ impl SourceBlockDecoder {
         constraint_matrix: impl BinaryMatrix,
         symbols: SymbolSlab,
     ) -> Option<Vec<u8>> {
-        let intermediate_symbols = match fused_inverse_mul_symbols_no_hdpc(
+        let computed = self.computed();
+        let intermediate_symbols = fused_inverse_mul_symbols_no_hdpc(
             constraint_matrix,
             symbols,
             self.source_block_symbols,
-        ) {
-            (None, _) => return None,
-            (Some(s), _) => s,
-        };
+            computed.num_intermediate_symbols,
+        )?;
 
         let mut result = vec![0; self.symbol_size as usize * self.source_block_symbols as usize];
-        let params = EncodingParameters {
-            lt_symbols: num_lt_symbols(self.source_block_symbols),
-            pi_symbols: num_pi_symbols(self.source_block_symbols),
-            sys_index: systematic_index(self.source_block_symbols),
-            p1: calculate_p1(self.source_block_symbols),
-        };
         let mut rebuilt_buf = vec![0u8; self.symbol_size as usize];
         for i in 0..self.source_block_symbols as usize {
             if let Some(ref symbol) = self.source_symbols[i] {
@@ -273,7 +288,7 @@ impl SourceBlockDecoder {
                     &mut rebuilt_buf,
                     &intermediate_symbols,
                     i as u32,
-                    params,
+                    computed.params,
                 );
                 self.unpack_sub_blocks(&mut result, &rebuilt_buf, i);
             }
@@ -413,13 +428,13 @@ impl SourceBlockDecoder {
         if num_extended_symbols >= self.sparse_threshold {
             let (constraint_matrix, hdpc) = generate_constraint_matrix::<SparseBinaryMatrix>(
                 self.source_block_symbols,
-                &encoded_isis,
+                encoded_isis.iter().cloned(),
             );
             self.try_pi_decode(constraint_matrix, hdpc, d)
         } else {
             let (constraint_matrix, hdpc) = generate_constraint_matrix::<DenseBinaryMatrix>(
                 self.source_block_symbols,
-                &encoded_isis,
+                encoded_isis.iter().cloned(),
             );
             self.try_pi_decode(constraint_matrix, hdpc, d)
         }

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -14,7 +14,7 @@ use crate::constraint_matrix::generate_constraint_matrix;
 use crate::matrix::DenseBinaryMatrix;
 use crate::octets::add_assign;
 use crate::operation_vector::{SymbolOps, perform_op};
-use crate::pi_solver::fused_inverse_mul_symbols;
+use crate::pi_solver::{fused_inverse_mul_symbol_ops, fused_inverse_mul_symbols};
 use crate::sparse_matrix::SparseBinaryMatrix;
 use crate::symbol_slab::SymbolSlab;
 use crate::systematic_constants::extended_source_block_symbols;
@@ -27,6 +27,7 @@ use crate::systematic_constants::{calculate_p1, systematic_index};
 use crate::util::int_div_ceil;
 #[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
+use likely_polyfill::likely;
 #[cfg(feature = "serde_support")]
 use serde::{Deserialize, Serialize};
 
@@ -174,17 +175,15 @@ impl Encoder {
 #[derive(Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serde_support", derive(Serialize, Deserialize))]
 pub struct SourceBlockEncodingPlan {
-    operations: Vec<SymbolOps>,
-    source_symbol_count: u16,
+    pub operations: Vec<SymbolOps>,
+    pub source_symbol_count: u16,
 }
 
 impl SourceBlockEncodingPlan {
     // Generates an encoding plan that is valid for any combination of data length and symbol size
     // where ceil(data_length / symbol_size) = symbol_count
     pub fn generate(symbol_count: u16) -> SourceBlockEncodingPlan {
-        // TODO: refactor pi_solver, so that we don't need this dummy data to generate a plan
-        let symbols = SymbolSlab::with_zeros(symbol_count as usize, 1);
-        let (_, ops) = gen_intermediate_symbols(&symbols, 1, SPARSE_MATRIX_THRESHOLD);
+        let ops = gen_intermediate_symbol_ops(symbol_count, 1, SPARSE_MATRIX_THRESHOLD);
         SourceBlockEncodingPlan {
             operations: ops.unwrap(),
             source_symbol_count: symbol_count,
@@ -301,7 +300,7 @@ impl SourceBlockEncoder {
             let intermediate_symbols = gen_intermediate_symbols_with_plan(
                 &source_symbols,
                 config.symbol_size() as usize,
-                &plan.operations,
+                plan.operations.iter().cloned(),
             );
             return SourceBlockEncoder {
                 source_block_id,
@@ -312,7 +311,7 @@ impl SourceBlockEncoder {
 
         #[cfg(not(feature = "std"))]
         {
-            let (intermediate_symbols, _operations) = gen_intermediate_symbols(
+            let intermediate_symbols = gen_intermediate_symbols(
                 &source_symbols,
                 config.symbol_size() as usize,
                 SPARSE_MATRIX_THRESHOLD,
@@ -339,7 +338,7 @@ impl SourceBlockEncoder {
         let intermediate_symbols = gen_intermediate_symbols_with_plan(
             &source_symbols,
             config.symbol_size() as usize,
-            &plan.operations,
+            plan.operations.iter().cloned(),
         );
 
         SourceBlockEncoder {
@@ -391,10 +390,14 @@ impl SourceBlockEncoder {
 }
 
 #[allow(non_snake_case)]
-fn create_d(source_block: &SymbolSlab, symbol_size: usize) -> SymbolSlab {
-    let L = num_intermediate_symbols(source_block.len() as u32);
+fn create_d(
+    source_block: &SymbolSlab,
+    symbol_size: usize,
+    extended_source_symbols: u32,
+) -> (SymbolSlab, u32) {
     let S = num_ldpc_symbols(source_block.len() as u32);
     let H = num_hdpc_symbols(source_block.len() as u32);
+    let L = extended_source_symbols + S + H;
 
     assert_eq!(source_block.symbol_size(), symbol_size);
     let mut D = SymbolSlab::with_zeros(L as usize, symbol_size);
@@ -402,39 +405,83 @@ fn create_d(source_block: &SymbolSlab, symbol_size: usize) -> SymbolSlab {
     // Copy source symbols into positions S+H..
     D.copy_block_from((S + H) as usize, source_block.as_bytes());
     // Extended padding symbols stay zero.
-    D
+    (D, L)
 }
 
 // See section 5.3.3.4
-#[allow(non_snake_case)]
+#[allow(non_snake_case, unused)]
 fn gen_intermediate_symbols(
     source_block: &SymbolSlab,
     symbol_size: usize,
     sparse_threshold: u32,
-) -> (Option<SymbolSlab>, Option<Vec<SymbolOps>>) {
+) -> Option<SymbolSlab> {
     let extended_source_symbols = extended_source_block_symbols(source_block.len() as u32);
-    let D = create_d(source_block, symbol_size);
-
-    let indices: Vec<u32> = (0..extended_source_symbols).collect();
-    let (intermediate_symbols, operations) = if extended_source_symbols >= sparse_threshold {
-        let (A, hdpc) =
-            generate_constraint_matrix::<SparseBinaryMatrix>(extended_source_symbols, &indices);
-        fused_inverse_mul_symbols(A, hdpc, D, extended_source_symbols)
+    let (D, L) = create_d(source_block, symbol_size, extended_source_symbols);
+    let intermediate_symbols = if likely(extended_source_symbols == source_block.len() as u32) {
+        L
     } else {
-        let (A, hdpc) =
-            generate_constraint_matrix::<DenseBinaryMatrix>(extended_source_symbols, &indices);
-        fused_inverse_mul_symbols(A, hdpc, D, extended_source_symbols)
+        num_intermediate_symbols(extended_source_symbols)
     };
 
-    (intermediate_symbols, operations)
+    if extended_source_symbols >= sparse_threshold {
+        let (A, hdpc) = generate_constraint_matrix::<SparseBinaryMatrix>(
+            extended_source_symbols,
+            0..extended_source_symbols,
+        );
+        fused_inverse_mul_symbols(A, hdpc, D, extended_source_symbols, intermediate_symbols)
+    } else {
+        let (A, hdpc) = generate_constraint_matrix::<DenseBinaryMatrix>(
+            extended_source_symbols,
+            0..extended_source_symbols,
+        );
+        fused_inverse_mul_symbols(A, hdpc, D, extended_source_symbols, intermediate_symbols)
+    }
 }
+
+// See section 5.3.3.4
+#[allow(non_snake_case)]
+fn gen_intermediate_symbol_ops(
+    symbol_count: u16,
+    symbol_size: usize,
+    sparse_threshold: u32,
+) -> Option<Vec<SymbolOps>> {
+    let extended_source_symbols = extended_source_block_symbols(symbol_count as u32);
+    let L = extended_source_symbols
+        + num_ldpc_symbols(symbol_count as u32)
+        + num_hdpc_symbols(symbol_count as u32);
+    let D = SymbolSlab::with_zeros(L as usize, symbol_size);
+    let intermediate_symbols = if likely(extended_source_symbols == symbol_count as u32) {
+        L
+    } else {
+        num_intermediate_symbols(extended_source_symbols)
+    };
+
+    if extended_source_symbols >= sparse_threshold {
+        let (A, hdpc) = generate_constraint_matrix::<SparseBinaryMatrix>(
+            extended_source_symbols,
+            0..extended_source_symbols,
+        );
+        fused_inverse_mul_symbol_ops(A, hdpc, D, extended_source_symbols, intermediate_symbols)
+    } else {
+        let (A, hdpc) = generate_constraint_matrix::<DenseBinaryMatrix>(
+            extended_source_symbols,
+            0..extended_source_symbols,
+        );
+        fused_inverse_mul_symbol_ops(A, hdpc, D, extended_source_symbols, intermediate_symbols)
+    }
+}
+
 #[allow(non_snake_case)]
 fn gen_intermediate_symbols_with_plan(
     source_block: &SymbolSlab,
     symbol_size: usize,
-    operation_vector: &[SymbolOps],
+    operation_vector: impl ExactSizeIterator<Item = SymbolOps>,
 ) -> SymbolSlab {
-    let mut D = create_d(source_block, symbol_size);
+    let (mut D, _) = create_d(
+        source_block,
+        symbol_size,
+        extended_source_block_symbols(source_block.len() as u32),
+    );
 
     for op in operation_vector {
         perform_op(op, &mut D);
@@ -537,7 +584,7 @@ mod tests {
     fn enc_constraint(sparse_threshold: u32) {
         let source_symbols = gen_test_symbols();
 
-        let (intermediate_symbols, _) =
+        let intermediate_symbols =
             gen_intermediate_symbols(&source_symbols, SYMBOL_SIZE, sparse_threshold);
         let intermediate_symbols = intermediate_symbols.unwrap();
 
@@ -565,7 +612,7 @@ mod tests {
 
     #[allow(non_snake_case)]
     fn ldpc_constraint(sparse_threshold: u32) {
-        let (intermediate_symbols, _) =
+        let intermediate_symbols =
             gen_intermediate_symbols(&gen_test_symbols(), SYMBOL_SIZE, sparse_threshold);
         let C = intermediate_symbols.unwrap();
         let S = num_ldpc_symbols(NUM_SYMBOLS) as usize;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,3 +79,5 @@ pub use crate::sparse_matrix::SparseBinaryMatrix;
 pub use crate::symbol::Symbol;
 #[cfg(feature = "benchmarking")]
 pub use crate::symbol_slab::SymbolSlab;
+#[cfg(feature = "benchmarking")]
+pub use crate::systematic_constants::num_intermediate_symbols;

--- a/src/operation_vector.rs
+++ b/src/operation_vector.rs
@@ -31,19 +31,19 @@ pub enum SymbolOps {
     },
 }
 
-pub fn perform_op(op: &SymbolOps, symbols: &mut SymbolSlab) {
+pub fn perform_op(op: SymbolOps, symbols: &mut SymbolSlab) {
     match op {
         SymbolOps::AddAssign { dest, src } => {
-            symbols.add_assign(*dest, *src);
+            symbols.add_assign(dest, src);
         }
         SymbolOps::MulAssign { dest, scalar } => {
-            symbols.mulassign_scalar(*dest, scalar);
+            symbols.mulassign_scalar(dest, &scalar);
         }
         SymbolOps::FMA { dest, src, scalar } => {
-            symbols.fma(*dest, *src, scalar);
+            symbols.fma(dest, src, &scalar);
         }
         SymbolOps::Reorder { order } => {
-            symbols.set_reorder(order.clone());
+            symbols.set_reorder(order);
         }
     }
 }
@@ -74,7 +74,7 @@ mod tests {
 
         let mut slab =
             SymbolSlab::from_symbols(vec![Symbol::new(raw0), Symbol::new(raw1)], symbol_size);
-        perform_op(&SymbolOps::AddAssign { dest: 0, src: 1 }, &mut slab);
+        perform_op(SymbolOps::AddAssign { dest: 0, src: 1 }, &mut slab);
         assert_eq!(expected, slab.get(0));
     }
 
@@ -99,7 +99,7 @@ mod tests {
         let mut slab =
             SymbolSlab::from_symbols(vec![Symbol::new(raw0), Symbol::new(raw1)], symbol_size);
         perform_op(
-            &SymbolOps::FMA {
+            SymbolOps::FMA {
                 dest: 0,
                 src: 1,
                 scalar: Octet::new(value),
@@ -124,7 +124,7 @@ mod tests {
 
         let mut slab = SymbolSlab::from_symbols(vec![Symbol::new(raw0)], symbol_size);
         perform_op(
-            &SymbolOps::MulAssign {
+            SymbolOps::MulAssign {
                 dest: 0,
                 scalar: Octet::new(value),
             },
@@ -148,7 +148,7 @@ mod tests {
         assert_eq!(slab.get(9)[0], 9);
 
         perform_op(
-            &SymbolOps::Reorder {
+            SymbolOps::Reorder {
                 order: vec![9, 7, 5, 3, 1, 8, 0, 6, 2, 4],
             },
             &mut slab,

--- a/src/pi_solver.rs
+++ b/src/pi_solver.rs
@@ -17,7 +17,6 @@ use crate::octets::BinaryOctetVec;
 use crate::operation_vector::SymbolOps;
 use crate::symbol_slab::SymbolSlab;
 use crate::systematic_constants::num_hdpc_symbols;
-use crate::systematic_constants::num_intermediate_symbols;
 use crate::systematic_constants::num_ldpc_symbols;
 use crate::systematic_constants::num_pi_symbols;
 
@@ -457,19 +456,14 @@ impl<T: BinaryMatrix> IntermediateSymbolDecoder<T> {
         hdpc_rows: DenseOctetMatrix,
         symbols: SymbolSlab,
         num_source_symbols: u32,
+        num_intermediate_symbols: u32,
     ) -> IntermediateSymbolDecoder<T> {
         assert!(matrix.width() <= symbols.len());
         assert_eq!(matrix.height(), symbols.len());
-        let mut c = Vec::with_capacity(matrix.width());
-        let mut d = Vec::with_capacity(symbols.len());
-        for i in 0..matrix.width() {
-            c.push(i);
-        }
-        for i in 0..symbols.len() {
-            d.push(i);
-        }
+        let c = (0..matrix.width()).collect();
+        let d = (0..symbols.len()).collect();
 
-        let intermediate_symbols = num_intermediate_symbols(num_source_symbols) as usize;
+        let intermediate_symbols = num_intermediate_symbols as usize;
 
         let num_rows = matrix.height();
 
@@ -525,19 +519,14 @@ impl<T: BinaryMatrix> IntermediateSymbolDecoder<T> {
         matrix: T,
         symbols: SymbolSlab,
         num_source_symbols: u32,
+        num_intermediate_symbols: u32,
     ) -> IntermediateSymbolDecoder<T> {
         assert!(matrix.width() <= symbols.len());
         assert_eq!(matrix.height(), symbols.len());
-        let mut c = Vec::with_capacity(matrix.width());
-        let mut d = Vec::with_capacity(symbols.len());
-        for i in 0..matrix.width() {
-            c.push(i);
-        }
-        for i in 0..symbols.len() {
-            d.push(i);
-        }
+        let c = (0..matrix.width()).collect();
+        let d = (0..symbols.len()).collect();
 
-        let intermediate_symbols = num_intermediate_symbols(num_source_symbols) as usize;
+        let intermediate_symbols = num_intermediate_symbols as usize;
         let pi_symbols = num_pi_symbols(num_source_symbols) as usize;
         #[cfg(debug_assertions)]
         let mut X = matrix.clone();
@@ -1341,7 +1330,7 @@ impl<T: BinaryMatrix> IntermediateSymbolDecoder<T> {
     }
 
     #[inline(never)]
-    pub fn execute(&mut self) -> (Option<SymbolSlab>, Option<Vec<SymbolOps>>) {
+    fn get_reorder(&mut self) -> Option<Vec<usize>> {
         #[cfg(debug_assertions)]
         self.X.disable_column_access_acceleration();
 
@@ -1349,14 +1338,14 @@ impl<T: BinaryMatrix> IntermediateSymbolDecoder<T> {
             self.A.disable_column_access_acceleration();
 
             if !self.second_phase(&x_elimination_ops) {
-                return (None, None);
+                return None;
             }
 
             self.third_phase(&x_elimination_ops);
             self.fourth_phase();
             self.fifth_phase(&x_elimination_ops);
         } else {
-            return (None, None);
+            return None;
         }
 
         self.apply_deferred_symbol_ops();
@@ -1367,18 +1356,26 @@ impl<T: BinaryMatrix> IntermediateSymbolDecoder<T> {
             index_mapping[self.c[i]] = self.d[i];
         }
 
-        // Keep D in-place and return logical reorder mapping.
-        // D.len() may be > L when decoder has overhead symbols.
-        let reorder: Vec<usize> = index_mapping[..self.L].to_vec();
+        Some(index_mapping)
+    }
 
-        let mut operation_vector = mem::take(&mut self.deferred_D_ops);
-        operation_vector.push(SymbolOps::Reorder {
-            order: reorder.clone(),
-        });
+    #[inline(never)]
+    pub fn execute(&mut self) -> Option<SymbolSlab> {
+        let reorder = self.get_reorder()?;
+
         self.D.set_reorder(reorder);
         let symbol_size = self.D.symbol_size();
         let result = mem::replace(&mut self.D, SymbolSlab::with_zeros(0, symbol_size));
-        return (Some(result), Some(operation_vector));
+        return Some(result);
+    }
+
+    #[inline(never)]
+    pub fn execute_ops(&mut self) -> Option<Vec<SymbolOps>> {
+        let reorder = self.get_reorder()?;
+
+        let mut operation_vector = mem::take(&mut self.deferred_D_ops);
+        operation_vector.push(SymbolOps::Reorder { order: reorder });
+        return Some(operation_vector);
     }
 }
 
@@ -1389,8 +1386,33 @@ pub fn fused_inverse_mul_symbols<T: BinaryMatrix>(
     hdpc_rows: DenseOctetMatrix,
     symbols: SymbolSlab,
     num_source_symbols: u32,
-) -> (Option<SymbolSlab>, Option<Vec<SymbolOps>>) {
-    IntermediateSymbolDecoder::new(matrix, hdpc_rows, symbols, num_source_symbols).execute()
+    num_intermediate_symbols: u32,
+) -> Option<SymbolSlab> {
+    IntermediateSymbolDecoder::new(
+        matrix,
+        hdpc_rows,
+        symbols,
+        num_source_symbols,
+        num_intermediate_symbols,
+    )
+    .execute()
+}
+
+pub fn fused_inverse_mul_symbol_ops<T: BinaryMatrix>(
+    matrix: T,
+    hdpc_rows: DenseOctetMatrix,
+    symbols: SymbolSlab,
+    num_source_symbols: u32,
+    num_intermediate_symbols: u32,
+) -> Option<Vec<SymbolOps>> {
+    IntermediateSymbolDecoder::new(
+        matrix,
+        hdpc_rows,
+        symbols,
+        num_source_symbols,
+        num_intermediate_symbols,
+    )
+    .execute_ops()
 }
 
 // Fused implementation without HDPC rows.
@@ -1399,8 +1421,15 @@ pub fn fused_inverse_mul_symbols_no_hdpc<T: BinaryMatrix>(
     matrix: T,
     symbols: SymbolSlab,
     num_source_symbols: u32,
-) -> (Option<SymbolSlab>, Option<Vec<SymbolOps>>) {
-    IntermediateSymbolDecoder::new_no_hdpc(matrix, symbols, num_source_symbols).execute()
+    num_intermediate_symbols: u32,
+) -> Option<SymbolSlab> {
+    IntermediateSymbolDecoder::new_no_hdpc(
+        matrix,
+        symbols,
+        num_source_symbols,
+        num_intermediate_symbols,
+    )
+    .execute()
 }
 
 #[cfg(feature = "std")]
@@ -1411,11 +1440,11 @@ mod tests {
     use crate::matrix::BinaryMatrix;
     use crate::matrix::DenseBinaryMatrix;
     use crate::symbol_slab::SymbolSlab;
+    use crate::systematic_constants::num_intermediate_symbols;
     use crate::systematic_constants::{
         MAX_SOURCE_SYMBOLS_PER_BLOCK, extended_source_block_symbols, num_ldpc_symbols,
         num_lt_symbols,
     };
-    use std::vec::Vec;
 
     #[test]
     fn operations_per_symbol() {
@@ -1423,10 +1452,16 @@ mod tests {
             [(10, 35.0, 50.0), (100, 16.0, 35.0)].iter()
         {
             let num_symbols = extended_source_block_symbols(elements);
-            let indices: Vec<u32> = (0..num_symbols).collect();
-            let (a, hdpc) = generate_constraint_matrix::<DenseBinaryMatrix>(num_symbols, &indices);
+            let (a, hdpc) =
+                generate_constraint_matrix::<DenseBinaryMatrix>(num_symbols, 0..num_symbols);
             let symbols = SymbolSlab::with_zeros(a.width(), 1);
-            let mut decoder = IntermediateSymbolDecoder::new(a, hdpc, symbols, num_symbols);
+            let mut decoder = IntermediateSymbolDecoder::new(
+                a,
+                hdpc,
+                symbols,
+                num_symbols,
+                num_intermediate_symbols(num_symbols),
+            );
             decoder.execute();
             assert!(
                 (decoder.get_symbol_mul_ops() as f64 / num_symbols as f64) < expected_mul_ops,


### PR DESCRIPTION
Provides decent performance improvement on Ryzen Max+ 395

Before:
```
     Running benches/decode_benchmark.rs (target/release/deps/decode_benchmark-1382f869cf209288)
Symbol size: 1280 bytes
symbol count = 10, decoded 127 MB in 0.213secs using 0.0% overhead, throughput: 4807.2Mbit/s
symbol count = 100, decoded 127 MB in 0.160secs using 0.0% overhead, throughput: 6396.5Mbit/s
symbol count = 250, decoded 127 MB in 0.158secs using 0.0% overhead, throughput: 6474.4Mbit/s
symbol count = 500, decoded 127 MB in 0.158secs using 0.0% overhead, throughput: 6458.9Mbit/s
symbol count = 1000, decoded 126 MB in 0.160secs using 0.0% overhead, throughput: 6347.7Mbit/s
symbol count = 2000, decoded 126 MB in 0.151secs using 0.0% overhead, throughput: 6726.0Mbit/s
symbol count = 5000, decoded 122 MB in 0.195secs using 0.0% overhead, throughput: 5008.0Mbit/s
symbol count = 10000, decoded 122 MB in 0.209secs using 0.0% overhead, throughput: 4672.5Mbit/s
symbol count = 20000, decoded 122 MB in 0.266secs using 0.0% overhead, throughput: 3671.3Mbit/s
symbol count = 50000, decoded 122 MB in 0.467secs using 0.0% overhead, throughput: 2091.1Mbit/s

symbol count = 10, decoded 127 MB in 0.223secs using 5.0% overhead, throughput: 4591.6Mbit/s
symbol count = 100, decoded 127 MB in 0.176secs using 5.0% overhead, throughput: 5815.0Mbit/s
symbol count = 250, decoded 127 MB in 0.172secs using 5.0% overhead, throughput: 5947.4Mbit/s
symbol count = 500, decoded 127 MB in 0.124secs using 5.0% overhead, throughput: 8229.9Mbit/s
symbol count = 1000, decoded 126 MB in 0.125secs using 5.0% overhead, throughput: 8125.0Mbit/s
symbol count = 2000, decoded 126 MB in 0.138secs using 5.0% overhead, throughput: 7359.6Mbit/s
symbol count = 5000, decoded 122 MB in 0.157secs using 5.0% overhead, throughput: 6220.1Mbit/s
symbol count = 10000, decoded 122 MB in 0.191secs using 5.0% overhead, throughput: 5112.9Mbit/s
symbol count = 20000, decoded 122 MB in 0.252secs using 5.0% overhead, throughput: 3875.2Mbit/s
symbol count = 50000, decoded 122 MB in 0.473secs using 5.0% overhead, throughput: 2064.6Mbit/s
     Running benches/encode_benchmark.rs (target/release/deps/encode_benchmark-4d87235d373d1b25)
Symbol size: 1280 bytes (without pre-built plan)
symbol count = 10, encoded 127 MB in 0.075secs, throughput: 13652.3Mbit/s
symbol count = 100, encoded 127 MB in 0.077secs, throughput: 13291.4Mbit/s
symbol count = 250, encoded 127 MB in 0.086secs, throughput: 11894.8Mbit/s
symbol count = 500, encoded 127 MB in 0.071secs, throughput: 14373.3Mbit/s
symbol count = 1000, encoded 126 MB in 0.091secs, throughput: 11160.7Mbit/s
symbol count = 2000, encoded 126 MB in 0.087secs, throughput: 11673.9Mbit/s
symbol count = 5000, encoded 122 MB in 0.079secs, throughput: 12361.6Mbit/s
symbol count = 10000, encoded 122 MB in 0.094secs, throughput: 10389.0Mbit/s
symbol count = 20000, encoded 122 MB in 0.127secs, throughput: 7689.5Mbit/s
symbol count = 50000, encoded 122 MB in 0.272secs, throughput: 3590.3Mbit/s

Symbol size: 1280 bytes (with pre-built plan)
symbol count = 10, encoded 127 MB in 0.079secs, throughput: 12961.1Mbit/s
symbol count = 100, encoded 127 MB in 0.056secs, throughput: 18275.7Mbit/s
symbol count = 250, encoded 127 MB in 0.062secs, throughput: 16499.2Mbit/s
symbol count = 500, encoded 127 MB in 0.047secs, throughput: 21712.9Mbit/s
symbol count = 1000, encoded 126 MB in 0.062secs, throughput: 16381.0Mbit/s
symbol count = 2000, encoded 126 MB in 0.062secs, throughput: 16381.0Mbit/s
symbol count = 5000, encoded 122 MB in 0.070secs, throughput: 13950.9Mbit/s
symbol count = 10000, encoded 122 MB in 0.060secs, throughput: 16276.0Mbit/s
symbol count = 20000, encoded 122 MB in 0.102secs, throughput: 9574.1Mbit/s
symbol count = 50000, encoded 122 MB in 0.227secs, throughput: 4302.0Mbit/s
```

After:
```
     Running benches/decode_benchmark.rs (target/release/deps/decode_benchmark-198bb112ae28ffe4)
Symbol size: 1280 bytes
symbol count = 10, decoded 127 MB in 0.204secs using 0.0% overhead, throughput: 5019.2Mbit/s
symbol count = 100, decoded 127 MB in 0.158secs using 0.0% overhead, throughput: 6477.5Mbit/s
symbol count = 250, decoded 127 MB in 0.160secs using 0.0% overhead, throughput: 6393.4Mbit/s
symbol count = 500, decoded 127 MB in 0.149secs using 0.0% overhead, throughput: 6849.0Mbit/s
symbol count = 1000, decoded 126 MB in 0.157secs using 0.0% overhead, throughput: 6468.9Mbit/s
symbol count = 2000, decoded 126 MB in 0.164secs using 0.0% overhead, throughput: 6192.8Mbit/s
symbol count = 5000, decoded 122 MB in 0.190secs using 0.0% overhead, throughput: 5139.8Mbit/s
symbol count = 10000, decoded 122 MB in 0.211secs using 0.0% overhead, throughput: 4628.3Mbit/s
symbol count = 20000, decoded 122 MB in 0.270secs using 0.0% overhead, throughput: 3616.9Mbit/s
symbol count = 50000, decoded 122 MB in 0.398secs using 0.0% overhead, throughput: 2453.7Mbit/s

symbol count = 10, decoded 127 MB in 0.191secs using 5.0% overhead, throughput: 5360.9Mbit/s
symbol count = 100, decoded 127 MB in 0.160secs using 5.0% overhead, throughput: 6396.5Mbit/s
symbol count = 250, decoded 127 MB in 0.151secs using 5.0% overhead, throughput: 6774.5Mbit/s
symbol count = 500, decoded 127 MB in 0.126secs using 5.0% overhead, throughput: 8099.3Mbit/s
symbol count = 1000, decoded 126 MB in 0.136secs using 5.0% overhead, throughput: 7467.8Mbit/s
symbol count = 2000, decoded 126 MB in 0.150secs using 5.0% overhead, throughput: 6770.8Mbit/s
symbol count = 5000, decoded 122 MB in 0.164secs using 5.0% overhead, throughput: 5954.6Mbit/s
symbol count = 10000, decoded 122 MB in 0.207secs using 5.0% overhead, throughput: 4717.7Mbit/s
symbol count = 20000, decoded 122 MB in 0.272secs using 5.0% overhead, throughput: 3590.3Mbit/s
symbol count = 50000, decoded 122 MB in 0.427secs using 5.0% overhead, throughput: 2287.0Mbit/s
     Running benches/encode_benchmark.rs (target/release/deps/encode_benchmark-ec550f3228c144f3)
Symbol size: 1280 bytes (without pre-built plan)
symbol count = 10, encoded 127 MB in 0.058secs, throughput: 17653.9Mbit/s
symbol count = 100, encoded 127 MB in 0.075secs, throughput: 13645.8Mbit/s
symbol count = 250, encoded 127 MB in 0.084secs, throughput: 12178.0Mbit/s
symbol count = 500, encoded 127 MB in 0.088secs, throughput: 11596.7Mbit/s
symbol count = 1000, encoded 126 MB in 0.073secs, throughput: 13912.7Mbit/s
symbol count = 2000, encoded 126 MB in 0.095secs, throughput: 10690.8Mbit/s
symbol count = 5000, encoded 122 MB in 0.078secs, throughput: 12520.0Mbit/s
symbol count = 10000, encoded 122 MB in 0.104secs, throughput: 9390.0Mbit/s
symbol count = 20000, encoded 122 MB in 0.112secs, throughput: 8719.3Mbit/s
symbol count = 50000, encoded 122 MB in 0.255secs, throughput: 3829.7Mbit/s

Symbol size: 1280 bytes (with pre-built plan)
symbol count = 10, encoded 127 MB in 0.078secs, throughput: 13127.3Mbit/s
symbol count = 100, encoded 127 MB in 0.039secs, throughput: 26242.0Mbit/s
symbol count = 250, encoded 127 MB in 0.061secs, throughput: 16769.7Mbit/s
symbol count = 500, encoded 127 MB in 0.063secs, throughput: 16198.5Mbit/s
symbol count = 1000, encoded 126 MB in 0.047secs, throughput: 21609.0Mbit/s
symbol count = 2000, encoded 126 MB in 0.067secs, throughput: 15158.6Mbit/s
symbol count = 5000, encoded 122 MB in 0.051secs, throughput: 19148.3Mbit/s
symbol count = 10000, encoded 122 MB in 0.079secs, throughput: 12361.6Mbit/s
symbol count = 20000, encoded 122 MB in 0.082secs, throughput: 11909.3Mbit/s
symbol count = 50000, encoded 122 MB in 0.164secs, throughput: 5954.6Mbit/s
```
