### PR TITLE
feat: encoder reuse

### DIFF
--- a/benches/encode_benchmark.rs
+++ b/benches/encode_benchmark.rs
@@ -1,9 +1,12 @@
 use rand::RngExt;
 use raptorq::{ObjectTransmissionInformation, SourceBlockEncoder, SourceBlockEncodingPlan};
+use std::collections::HashMap;
 use std::time::Instant;
 
-const TARGET_TOTAL_BYTES: usize = 128 * 1024 * 1024;
+const TARGET_TOTAL_BYTES: usize = 512 * 1024 * 1024;
 const SYMBOL_COUNTS: [usize; 10] = [10, 100, 250, 500, 1000, 2000, 5000, 10000, 20000, 50000];
+// A more realistic set of symbols for live streaming:
+// const SYMBOL_COUNTS: [usize; 15] = [2, 3, 5, 7, 10, 14, 20, 30, 42, 90, 100, 120, 150, 200, 250];
 
 fn black_box(value: u64) {
     if value == rand::rng().random() {
@@ -11,8 +14,10 @@ fn black_box(value: u64) {
     }
 }
 
-fn benchmark(symbol_size: u16, pre_plan: bool) -> u64 {
+fn benchmark(symbol_size: u16, pre_plan: bool, with_cached: bool) -> u64 {
     let mut black_box_value = 0;
+    let mut encoder_cache: HashMap<usize, SourceBlockEncoder> = HashMap::new();
+
     for symbol_count in SYMBOL_COUNTS.iter() {
         let elements = symbol_count * symbol_size as usize;
         let mut data: Vec<u8> = vec![0; elements];
@@ -20,32 +25,50 @@ fn benchmark(symbol_size: u16, pre_plan: bool) -> u64 {
             *byte = rand::rng().random();
         }
 
-        let plan = if pre_plan {
+        let plan = if pre_plan || with_cached {
             Some(SourceBlockEncodingPlan::generate(*symbol_count as u16))
         } else {
             None
         };
 
+        let config = ObjectTransmissionInformation::new(0, symbol_size, 0, 1, 1);
+
+        if with_cached && plan.is_some() {
+            encoder_cache.entry(*symbol_count).or_insert_with(|| {
+                SourceBlockEncoder::with_encoding_plan(1, &config, &data, plan.as_ref().unwrap())
+            });
+        }
+
         let now = Instant::now();
         let iterations = TARGET_TOTAL_BYTES / elements;
-        let config = ObjectTransmissionInformation::new(0, symbol_size, 0, 1, 1);
         for _ in 0..iterations {
-            let encoder = if let Some(ref plan) = plan {
-                SourceBlockEncoder::with_encoding_plan(1, &config, &data, plan)
+            let packets = if with_cached {
+                let encoder = encoder_cache.get_mut(symbol_count).unwrap();
+                encoder.reset(&data, plan.as_ref().unwrap());
+                encoder.repair_packets(0, 1)
             } else {
-                SourceBlockEncoder::new(1, &config, &data)
+                let fresh_plan;
+                let plan_ref = if let Some(ref plan) = plan {
+                    plan
+                } else {
+                    fresh_plan = SourceBlockEncodingPlan::generate(*symbol_count as u16);
+                    &fresh_plan
+                };
+                SourceBlockEncoder::with_encoding_plan(1, &config, &data, plan_ref)
+                    .repair_packets(0, 1)
             };
-            let packets = encoder.repair_packets(0, 1);
             black_box_value += packets[0].data()[0] as u64;
         }
         let elapsed = now.elapsed();
         let elapsed = elapsed.as_secs() as f64 + elapsed.subsec_millis() as f64 * 0.001;
         let throughput = (elements * iterations * 8) as f64 / 1024.0 / 1024.0 / elapsed;
         println!(
-            "symbol count = {}, encoded {} MB in {:.3}secs, throughput: {:.1}Mbit/s",
+            "symbol count = {}, iters = {}, encoded {} MB in {:.3}secs ({:.4}ms per iter), throughput: {:.1}Mbit/s",
             symbol_count,
+            iterations,
             elements * iterations / 1024 / 1024,
             elapsed,
+            elapsed * 1000.0 / iterations as f64,
             throughput
         );
     }
@@ -54,9 +77,25 @@ fn benchmark(symbol_size: u16, pre_plan: bool) -> u64 {
 
 fn main() {
     let symbol_size = 1280;
-    println!("Symbol size: {symbol_size} bytes (without pre-built plan)");
-    black_box(benchmark(symbol_size, false));
-    println!();
-    println!("Symbol size: {symbol_size} bytes (with pre-built plan)");
-    black_box(benchmark(symbol_size, true));
+    let variant = std::env::args().nth(1).unwrap_or_default();
+    match variant.as_str() {
+        "no-plan" => {
+            println!("Symbol size: {symbol_size} bytes (fresh plan each iteration)");
+            black_box(benchmark(symbol_size, false, false));
+        }
+        "pre-plan" => {
+            println!("Symbol size: {symbol_size} bytes (with pre-built plan)");
+            black_box(benchmark(symbol_size, true, false));
+        }
+        "cached" => {
+            println!("Symbol size: {symbol_size} bytes (cached encoder)");
+            black_box(benchmark(symbol_size, true, true));
+        }
+        _ => {
+            println!("usage: encode_benchmark <no-plan|pre-plan|cached>");
+            println!("  no-plan   fresh plan generated each iteration (true cold cost)");
+            println!("  pre-plan  new encoder each iteration, pre-built plan");
+            println!("  cached    encoder reused via reset(), pre-built plan");
+        }
+    }
 }

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -349,6 +349,41 @@ impl SourceBlockEncoder {
         }
     }
 
+    /// Reset the encoder to encode new data of the same K
+    /// Panics if plan K, data K, or data length do not match the encoder's K.
+    pub fn reset(&mut self, data: &[u8], plan: &SourceBlockEncodingPlan) {
+        let k = self.source_symbols.len();
+        let sym_size = self.intermediate_symbols.symbol_size();
+
+        assert_eq!(
+            k, plan.source_symbol_count as usize,
+            "plan K={} does not match encoder K={}",
+            plan.source_symbol_count, k
+        );
+        assert_eq!(
+            data.len(), k * sym_size,
+            "data must be padded to K*sym_size={} bytes, got {}",
+            k * sym_size, data.len()
+        );
+
+        let s = num_ldpc_symbols(k as u32) as usize;
+        let h = num_hdpc_symbols(k as u32) as usize;
+
+        // source_symbols has no mapping — copy_block_from writes to physical layout.
+        self.source_symbols.copy_block_from(0, data);
+
+        // rebuild D
+        self.intermediate_symbols.zero();
+        for i in 0..k {
+            self.intermediate_symbols
+                .get_mut(s + h + i)
+                .copy_from_slice(self.source_symbols.get(i));
+        }
+        for op in &plan.operations {
+            perform_op(op, &mut self.intermediate_symbols);
+        }
+    }
+
     pub fn source_packets(&self) -> Vec<EncodingPacket> {
         (0..self.source_symbols.len())
             .map(|i| {
@@ -627,6 +662,68 @@ mod tests {
                 .collect::<Vec<_>>(),
             &[5, 6, 7, 8]
         );
+    }
+
+    #[test]
+    fn reset_produces_same_output_as_new() {
+        let symbol_size = 2;
+        let data: [u8; 6] = [0, 1, 2, 3, 4, 5];
+        let config = ObjectTransmissionInformation::new(0, symbol_size, 1, 1, 1);
+        let mut encoder = SourceBlockEncoder::new(0, &config, &data);
+
+        let source_before = encoder.source_packets();
+        let repair_before = encoder.repair_packets(0, 3);
+
+        let plan = SourceBlockEncodingPlan::generate(3);
+        encoder.reset(&data, &plan);
+
+        assert_eq!(encoder.source_packets(), source_before);
+        assert_eq!(encoder.repair_packets(0, 3), repair_before);
+    }
+
+    #[test]
+    fn reset_with_different_data_produces_different_output() {
+        let symbol_size = 2;
+        let data_1: [u8; 6] = [0, 1, 2, 3, 4, 5];
+        let data_2: [u8; 6] = [10, 11, 12, 13, 14, 15];
+        let config = ObjectTransmissionInformation::new(0, symbol_size, 1, 1, 1);
+        let mut encoder = SourceBlockEncoder::new(0, &config, &data_1);
+
+        let repair_before = encoder.repair_packets(0, 1);
+
+        let plan = SourceBlockEncodingPlan::generate(3);
+        encoder.reset(&data_2, &plan);
+
+        assert_ne!(encoder.repair_packets(0, 1), repair_before);
+        assert_eq!(
+            encoder.source_packets(),
+            [[10u8, 11], [12, 13], [14, 15]]
+                .into_iter()
+                .enumerate()
+                .map(|(i, d)| EncodingPacket::new(PayloadId::new(0, i as u32), d.into()))
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn reset_roundtrip_decodes_new_data() {
+        let symbol_size = 2;
+        let data_1: [u8; 6] = [0, 1, 2, 3, 4, 5];
+        let data_2: [u8; 6] = [10, 11, 12, 13, 14, 15];
+        let config = ObjectTransmissionInformation::new(0, symbol_size, 1, 1, 1);
+        let mut encoder = SourceBlockEncoder::new(0, &config, &data_1);
+
+        let plan = SourceBlockEncodingPlan::generate(3);
+        encoder.reset(&data_2, &plan);
+
+        // Repair-only forces the decoder to run the full linear algebra path,
+        // verifying that intermediate_symbols were correctly regenerated from data_2.
+        let repair_packets = encoder.repair_packets(0, 3);
+
+        let mut decoder = crate::SourceBlockDecoder::new(0, &config, 6);
+        let result = decoder.decode(repair_packets);
+
+        assert_eq!(result.unwrap(), data_2.to_vec());
     }
 
     #[cfg(not(feature = "python"))]

--- a/src/symbol_slab.rs
+++ b/src/symbol_slab.rs
@@ -184,6 +184,12 @@ impl SymbolSlab {
         self.mapping = Some(order);
     }
 
+    /// Zero all symbol data and clear any reorder mapping.
+    pub fn zero(&mut self) {
+        self.data.fill(0);
+        self.mapping = None;
+    }
+
     /// Bulk copy from a contiguous source block into the slab at the given offset.
     /// `source` must be `count * symbol_size` bytes.
     #[allow(dead_code)]
@@ -266,6 +272,30 @@ mod tests {
         assert_eq!(slab.get(0), &[2]);
         assert_eq!(slab.get(1), &[0]);
         assert_eq!(slab.get(2), &[1]);
+    }
+
+    #[test]
+    fn zero_clears_data_and_mapping() {
+        let mut slab = SymbolSlab::from_symbols(
+            vec![
+                Symbol::new(vec![0xAA, 0xBB]),
+                Symbol::new(vec![0xCC, 0xDD]),
+            ],
+            2,
+        );
+        slab.set_reorder(vec![1, 0]);
+        assert_eq!(slab.get(0), &[0xCC, 0xDD]);
+        assert_eq!(slab.get(1), &[0xAA, 0xBB]);
+
+        slab.zero();
+
+        assert_eq!(slab.get(0), &[0x00, 0x00]);
+        assert_eq!(slab.get(1), &[0x00, 0x00]);
+
+        // check mapping is cleared with a sentinel at slot 0
+        slab.copy_block_from(0, &[0xAB, 0xCD]);
+        assert_eq!(slab.get(0), &[0xAB, 0xCD]);
+        assert_eq!(slab.get(1), &[0x00, 0x00]);
     }
 
     #[test]


### PR DESCRIPTION
This PR updates encoder's interface to allow user to "reset" an encoder with new data of same symbol count. 
This enables bypassing allocations on encoder creation and allows user to maintain their own cache of encoder for re-use purposes. 