### PR TITLE
Update pyo3 to 0.29.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ crate-type = ["lib"]
 
 [dependencies]
 serde = {version = "1.0.102", features=["std", "derive"], optional = true}
-pyo3 = {version = "0.24.1", features=["extension-module", "abi3-py37"], optional = true }
+pyo3 = {version = "0.29.0", features=["extension-module", "abi3-py38"], optional = true }
 
 [dev-dependencies]
 criterion = "0.5"

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ $ pip install maturin
 $ maturin build --features python
 ```
 
-Alternatively, refer to the [Building and Distribution section](https://pyo3.rs/v0.8.5/building_and_distribution.html) in the [pyo3 user guide](https://pyo3.rs/v0.8.5/).
+Alternatively, refer to the [Building and Distribution section](https://pyo3.rs/v0.29.0/building-and-distribution.html) in the [pyo3 user guide](https://pyo3.rs/v0.29.0/).
 Note, you must pass the `--cargo-extra-args="--features python"` argument to Maturin when building this crate
 to enable the Python binding features.
 

--- a/benches/decode_benchmark.rs
+++ b/benches/decode_benchmark.rs
@@ -6,7 +6,7 @@ const TARGET_TOTAL_BYTES: usize = 128 * 1024 * 1024;
 const SYMBOL_COUNTS: [usize; 10] = [10, 100, 250, 500, 1000, 2000, 5000, 10000, 20000, 50000];
 
 fn black_box(value: u64) {
-    if value == rand::rng().random() {
+    if value == rand::rng().random::<u64>() {
         println!("{value}");
     }
 }

--- a/benches/encode_benchmark.rs
+++ b/benches/encode_benchmark.rs
@@ -6,7 +6,7 @@ const TARGET_TOTAL_BYTES: usize = 128 * 1024 * 1024;
 const SYMBOL_COUNTS: [usize; 10] = [10, 100, 250, 500, 1000, 2000, 5000, 10000, 20000, 50000];
 
 fn black_box(value: u64) {
-    if value == rand::rng().random() {
+    if value == rand::rng().random::<u64>() {
         println!("{value}");
     }
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "raptorq"
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 dynamic = ["version"]
 classifier = ["Development Status :: 4 - Beta",
     "License :: OSI Approved :: Apache Software License",


### PR DESCRIPTION
Bumps pyo3 from `0.24.1` to the latest `0.29.0`.

## Changes

- **`Cargo.toml`** — pyo3 `0.24.1` → `0.29.0`. Python 3.7 reached end-of-life and the `abi3-py37` feature was removed upstream, so the stable-ABI floor moves to `abi3-py38`.
- **`benches/{encode,decode}_benchmark.rs`** — pyo3 0.29 adds `impl PartialEq<Bound<'_, PyInt>> for u64`, which made `value == rand::rng().random()` type-ambiguous when the `python` feature is compiled alongside the benchmark targets. Annotated the call with an explicit `::<u64>()`.
- **`README.md`** — refreshed the stale pyo3 user-guide links (`v0.8.5` → `v0.29.0`); the building-and-distribution page was also renamed from underscores to hyphens upstream.

No changes were needed in `src/python.rs` — the binding code compiles against 0.29 as-is.

## Verification

- `cargo clippy --all --all-targets -- -Dwarnings` (matches CI) — clean
- `cargo fmt --all -- --check` — clean
- `cargo build --features benchmarking,python,serde_support` — builds
- `cargo test --features benchmarking` — 63 passed
- `cargo bench --features benchmarking --no-run` — compiles
- `cargo test --no-default-features` — passes
- `maturin develop` + `python3 -m unittest discover` — Encoder/Decoder tests pass against the new pyo3
- License check of the full 0.29 dependency tree (92 crates) — all within the `deny.toml` allowlist

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fi4Noro5B42QJdw7eVnv8r

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fi4Noro5B42QJdw7eVnv8r)_