### PR TITLE
Release the GIL during encode/decode in the Python bindings

### DIFF
--- a/src/python.rs
+++ b/src/python.rs
@@ -28,7 +28,7 @@ impl Encoder {
         repair_packets_per_block: u32,
     ) -> PyResult<Vec<Py<PyBytes>>> {
         // Release the GIL during the CPU-bound encoding + serialization.
-        let raw: Vec<Vec<u8>> = py.allow_threads(|| {
+        let raw: Vec<Vec<u8>> = py.detach(|| {
             self.encoder
                 .get_encoded_packets(repair_packets_per_block)
                 .iter()
@@ -71,7 +71,7 @@ impl Decoder {
     ) -> PyResult<Option<Py<PyBytes>>> {
         // Copy bytes out before releasing the GIL (PyBytes is a Python object).
         let packet_bytes = packet.as_bytes().to_vec();
-        let result: Option<Vec<u8>> = py.allow_threads(|| {
+        let result: Option<Vec<u8>> = py.detach(|| {
             self.decoder
                 .decode(EncodingPacket::deserialize(&packet_bytes))
         });

--- a/src/python.rs
+++ b/src/python.rs
@@ -1,3 +1,4 @@
+use std::sync::Mutex;
 use std::vec::Vec;
 
 use crate::base::{EncodingPacket, ObjectTransmissionInformation};
@@ -6,8 +7,8 @@ use crate::encoder::Encoder as EncoderNative;
 use pyo3::prelude::*;
 use pyo3::types::*;
 
-#[pyclass]
-pub struct Encoder {
+#[pyclass(frozen)]
+struct Encoder {
     encoder: EncoderNative,
 }
 
@@ -22,12 +23,11 @@ impl Encoder {
         Ok(Encoder { encoder })
     }
     
-    pub fn get_encoded_packets(
+    fn get_encoded_packets(
         &self,
         py: Python<'_>,
         repair_packets_per_block: u32,
     ) -> PyResult<Vec<Py<PyBytes>>> {
-        // Release the GIL during the CPU-bound encoding + serialization.
         let raw: Vec<Vec<u8>> = py.detach(|| {
             self.encoder
                 .get_encoded_packets(repair_packets_per_block)
@@ -35,18 +35,43 @@ impl Encoder {
                 .map(|packet| packet.serialize())
                 .collect()
         });
-        // GIL is held again here: safe to create Python objects.
-        let packets = raw
-            .iter()
-            .map(|bytes| PyBytes::new(py, bytes).into())
-            .collect();
-        Ok(packets)
+        Ok(raw.iter().map(|bytes| PyBytes::new(py, bytes).into()).collect())
     }
 }
 
-#[pyclass]
-pub struct Decoder {
-    decoder: DecoderNative,
+#[pyclass(frozen)]
+struct Decoder {
+    decoder: Mutex<DecoderNative>,
+}
+
+#[pymethods]
+impl Decoder {
+    #[staticmethod]
+    fn with_defaults(
+        transfer_length: u64,
+        maximum_transmission_unit: u16,
+    ) -> Decoder {
+        let config = ObjectTransmissionInformation::with_defaults(
+            transfer_length,
+            maximum_transmission_unit,
+        );
+        Decoder { decoder: Mutex::new(DecoderNative::new(config)) }
+    }
+
+    fn decode(
+        &self,
+        py: Python<'_>,
+        packet: Bound<'_, PyBytes>,
+    ) -> PyResult<Option<Py<PyBytes>>> {
+        let packet_bytes = packet.as_bytes().to_vec();
+        let result: Option<Vec<u8>> = py.detach(|| {
+            self.decoder
+                .lock()
+                .unwrap()
+                .decode(EncodingPacket::deserialize(&packet_bytes))
+        });
+        Ok(result.map(|data| PyBytes::new(py, &data).into()))
+    }
 }
 
 #[pymethods]

--- a/src/python.rs
+++ b/src/python.rs
@@ -74,36 +74,6 @@ impl Decoder {
     }
 }
 
-#[pymethods]
-impl Decoder {
-    #[staticmethod]
-    pub fn with_defaults(
-        transfer_length: u64,
-        maximum_transmission_unit: u16,
-    ) -> PyResult<Decoder> {
-        let config = ObjectTransmissionInformation::with_defaults(
-            transfer_length,
-            maximum_transmission_unit,
-        );
-        let decoder = DecoderNative::new(config);
-        Ok(Decoder { decoder })
-    }
-
-    pub fn decode(
-        &mut self,
-        py: Python<'_>,
-        packet: Bound<'_, PyBytes>,
-    ) -> PyResult<Option<Py<PyBytes>>> {
-        // Copy bytes out before releasing the GIL (PyBytes is a Python object).
-        let packet_bytes = packet.as_bytes().to_vec();
-        let result: Option<Vec<u8>> = py.detach(|| {
-            self.decoder
-                .decode(EncodingPacket::deserialize(&packet_bytes))
-        });
-        Ok(result.map(|data| PyBytes::new(py, &data).into()))
-    }
-}
-
 #[pymodule]
 pub fn raptorq(_py: Python<'_>, m: Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<Encoder>()?;

--- a/src/python.rs
+++ b/src/python.rs
@@ -21,19 +21,25 @@ impl Encoder {
         let encoder = EncoderNative::with_defaults(data.as_bytes(), maximum_transmission_unit);
         Ok(Encoder { encoder })
     }
-
+    
     pub fn get_encoded_packets(
         &self,
         py: Python<'_>,
         repair_packets_per_block: u32,
     ) -> PyResult<Vec<Py<PyBytes>>> {
-        let packets: Vec<Py<PyBytes>> = self
-            .encoder
-            .get_encoded_packets(repair_packets_per_block)
+        // Release the GIL during the CPU-bound encoding + serialization.
+        let raw: Vec<Vec<u8>> = py.allow_threads(|| {
+            self.encoder
+                .get_encoded_packets(repair_packets_per_block)
+                .iter()
+                .map(|packet| packet.serialize())
+                .collect()
+        });
+        // GIL is held again here: safe to create Python objects.
+        let packets = raw
             .iter()
-            .map(|packet| PyBytes::new(py, &packet.serialize()).into())
+            .map(|bytes| PyBytes::new(py, bytes).into())
             .collect();
-
         Ok(packets)
     }
 }
@@ -63,9 +69,12 @@ impl Decoder {
         py: Python<'_>,
         packet: Bound<'_, PyBytes>,
     ) -> PyResult<Option<Py<PyBytes>>> {
-        let result = self
-            .decoder
-            .decode(EncodingPacket::deserialize(packet.as_bytes()));
+        // Copy bytes out before releasing the GIL (PyBytes is a Python object).
+        let packet_bytes = packet.as_bytes().to_vec();
+        let result: Option<Vec<u8>> = py.allow_threads(|| {
+            self.decoder
+                .decode(EncodingPacket::deserialize(&packet_bytes))
+        });
         Ok(result.map(|data| PyBytes::new(py, &data).into()))
     }
 }


### PR DESCRIPTION
## Summary

The Python bindings hold the GIL for the entire duration of
`Encoder.get_encoded_packets` and `Decoder.decode`, even though the heavy
work is pure Rust and never touches any Python object. As a result these
calls are serialized across threads: a multi-threaded Python application
cannot encode or decode on several cores in parallel, despite the
underlying Rust code being perfectly thread-safe.

This PR wraps the native computation in `py.detach(...)`, releasing
the GIL while encoding/decoding and re-acquiring it only to build the
returned `bytes` objects.

## Motivation

`get_encoded_packets` and `decode` are CPU-bound and can dominate runtime
for large objects or high packet rates. Today:

- `concurrent.futures.ThreadPoolExecutor` and `asyncio.run_in_executor`
  give **no** speedup for these calls, because the GIL is held throughout.
- Users are forced to fall back to multiprocessing to use multiple cores,
  which is heavier (pickling or shared-memory IPC) and more complex.

Releasing the GIL around the native work is the idiomatic PyO3 way to let
Python threads run RaptorQ on multiple cores concurrently.

## Why it is safe

- The closure passed to `detach` runs **pure Rust** and does not
  touch `py` or any Python object.
- In `decode`, the input bytes are copied out of the `PyBytes` (a single
  packet, negligible) **before** the GIL is released.
- Returned `PyBytes` are built **after** the GIL is re-acquired.
- PyO3's `Ungil` bound enforces at compile time that no Python object
  crosses the boundary. The encoder/decoder state is plain data (`Send`).

## Public API

No change. Behavior is identical; the calls simply become concurrency
friendly.

## Note

The PyPI wheel is currently 2.0.0 while the crate is at 2.0.1; it would be
great to publish a refreshed wheel that also includes this change.