### PR TITLE
perf: avoid memzero of source region when building intermediate D

### DIFF
--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -397,12 +397,17 @@ fn create_d(source_block: &SymbolSlab, symbol_size: usize) -> SymbolSlab {
     let H = num_hdpc_symbols(source_block.len() as u32);
 
     assert_eq!(source_block.symbol_size(), symbol_size);
-    let mut D = SymbolSlab::with_zeros(L as usize, symbol_size);
-    // First S+H entries are zero (already set).
-    // Copy source symbols into positions S+H..
-    D.copy_block_from((S + H) as usize, source_block.as_bytes());
-    // Extended padding symbols stay zero.
-    D
+    // D layout (RFC 6330 §5.3.3.4):
+    //   [0, S+H)           — zero RHS for LDPC/HDPC rows
+    //   [S+H, S+H+K)       — source symbols
+    //   [S+H+K, L)         — zero padding for K'..K extended symbols
+    // Avoid memzero of the source region (K * T bytes) on the hot encode path.
+    SymbolSlab::with_zero_prefix_source_and_padding(
+        L as usize,
+        symbol_size,
+        (S + H) as usize,
+        source_block.as_bytes(),
+    )
 }
 
 // See section 5.3.3.4

--- a/src/symbol_slab.rs
+++ b/src/symbol_slab.rs
@@ -39,6 +39,52 @@ impl SymbolSlab {
         }
     }
 
+    /// Build a slab of `total_symbols` with:
+    /// - `zero_prefix_symbols` leading all-zero symbols,
+    /// - then the contiguous `source` bytes (must be a multiple of `symbol_size`),
+    /// - then zero-filled padding through `total_symbols`.
+    ///
+    /// Unlike [`with_zeros`] + overwrite, the source region is never memzero'd.
+    pub(crate) fn with_zero_prefix_source_and_padding(
+        total_symbols: usize,
+        symbol_size: usize,
+        zero_prefix_symbols: usize,
+        source: &[u8],
+    ) -> Self {
+        assert!(symbol_size > 0, "symbol_size must be non-zero");
+        assert_eq!(
+            source.len() % symbol_size,
+            0,
+            "source length must be a multiple of symbol_size"
+        );
+        let source_symbols = source.len() / symbol_size;
+        assert!(
+            zero_prefix_symbols
+                .checked_add(source_symbols)
+                .is_some_and(|used| used <= total_symbols),
+            "prefix+source exceeds total_symbols"
+        );
+        let total_bytes = total_symbols
+            .checked_mul(symbol_size)
+            .expect("slab byte length overflow");
+        let prefix_bytes = zero_prefix_symbols * symbol_size;
+
+        let mut data = Vec::with_capacity(total_bytes);
+        // Zero only the constraint prefix.
+        data.resize(prefix_bytes, 0);
+        // Copy source without a prior memset of that region.
+        data.extend_from_slice(source);
+        // Zero only the trailing padding (K'..K and any unused tail).
+        data.resize(total_bytes, 0);
+
+        SymbolSlab {
+            data,
+            count: total_symbols,
+            symbol_size,
+            mapping: None,
+        }
+    }
+
     /// Create a slab from already-contiguous symbol bytes.
     pub(crate) fn from_bytes(data: Vec<u8>, symbol_size: usize) -> Self {
         assert!(symbol_size > 0, "symbol_size must be non-zero");
@@ -276,5 +322,19 @@ mod tests {
         slab.fma(0, 1, &scalar);
         // GF(256): 0x01 ^ (0x02 * 3) = 0x01 ^ 0x06 = 0x07
         assert_eq!(slab.get(0), &[0x07]);
+    }
+
+    #[test]
+    fn zero_prefix_source_and_padding_layout() {
+        // 2 zero prefix + 2 source + 1 padding = 5 symbols of size 3
+        let source = vec![1, 2, 3, 4, 5, 6];
+        let slab = SymbolSlab::with_zero_prefix_source_and_padding(5, 3, 2, &source);
+        assert_eq!(slab.len(), 5);
+        assert_eq!(slab.get(0), &[0, 0, 0]);
+        assert_eq!(slab.get(1), &[0, 0, 0]);
+        assert_eq!(slab.get(2), &[1, 2, 3]);
+        assert_eq!(slab.get(3), &[4, 5, 6]);
+        assert_eq!(slab.get(4), &[0, 0, 0]);
+        assert_eq!(slab.as_bytes().len(), 15);
     }
 }


### PR DESCRIPTION
## Summary
- `create_d` previously zeroed all `L * T` intermediate bytes then overwrote the K source symbols.
- Allocate with a zeroed LDPC/HDPC prefix, copy source, then zero only the K'−K padding tail.
- Skips ~K·T bytes of memset on the hot encode / with-plan path.

## E2E (Zen5 EPYC 9845, `taskset -c 0`, symbol_size=1280)
| cell | baseline | after | delta |
|------|--------:|------:|------:|
| e2e_repair_only K=1000 | 336.8 | 365.5 MiB/s | **+8.5%** |
| e2e_source_only K=1000 | 1030.9 | 1018.4 | -1.2% (noise) |
| encode_only K=1000 | 853.3 | 883.6 | +3.6% |
| e2e_repair_only K=5000 | 269.0 | 299.7 | +11.4% |

## Test plan
- [x] `cargo test --release` (64 passed)
- [x] Single-core E2E harness (`examples/e2e_perf`)