### PR TITLE
perf: bulk HDPC GE fill (stacked on create_d selective zero)

### DIFF
--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -397,12 +397,17 @@ fn create_d(source_block: &SymbolSlab, symbol_size: usize) -> SymbolSlab {
     let H = num_hdpc_symbols(source_block.len() as u32);
 
     assert_eq!(source_block.symbol_size(), symbol_size);
-    let mut D = SymbolSlab::with_zeros(L as usize, symbol_size);
-    // First S+H entries are zero (already set).
-    // Copy source symbols into positions S+H..
-    D.copy_block_from((S + H) as usize, source_block.as_bytes());
-    // Extended padding symbols stay zero.
-    D
+    // D layout (RFC 6330 §5.3.3.4):
+    //   [0, S+H)           — zero RHS for LDPC/HDPC rows
+    //   [S+H, S+H+K)       — source symbols
+    //   [S+H+K, L)         — zero padding for K'..K extended symbols
+    // Avoid memzero of the source region (K * T bytes) on the hot encode path.
+    SymbolSlab::with_zero_prefix_source_and_padding(
+        L as usize,
+        symbol_size,
+        (S + H) as usize,
+        source_block.as_bytes(),
+    )
 }
 
 // See section 5.3.3.4

--- a/src/octet_matrix.rs
+++ b/src/octet_matrix.rs
@@ -95,4 +95,23 @@ impl DenseOctetMatrix {
             fused_addassign_mul_scalar(dest_row, temp_row, scalar);
         }
     }
+
+    /// Borrow a full matrix row as bytes.
+    #[inline]
+    pub fn row_as_slice(&self, row: usize) -> &[u8] {
+        &self.elements[row]
+    }
+
+    /// Copy `src` into `row` starting at `start_col` (bulk fill helper for GE).
+    #[inline]
+    pub fn copy_row_segment(&mut self, row: usize, start_col: usize, src: &[u8]) {
+        let end = start_col + src.len();
+        self.elements[row][start_col..end].copy_from_slice(src);
+    }
+
+    /// Write a single byte without constructing an [`Octet`].
+    #[inline]
+    pub fn set_byte(&mut self, i: usize, j: usize, value: u8) {
+        self.elements[i][j] = value;
+    }
 }

--- a/src/pi_solver.rs
+++ b/src/pi_solver.rs
@@ -1117,18 +1117,22 @@ impl<T: BinaryMatrix> IntermediateSymbolDecoder<T> {
         col_offset: usize,
         size: usize,
     ) -> Option<DenseOctetMatrix> {
-        // Copy U_lower into a new matrix and merge it with the HDPC rows
+        // Copy U_lower into a new matrix and merge it with the HDPC rows.
+        // HDPC rows are already dense GF(256): bulk-copy each row segment.
+        // Binary A rows still need per-column extraction (bit-packed source).
         let mut submatrix = DenseOctetMatrix::new(self.A.height() - row_offset, size, 0);
         let first_hdpc_row = self.A.height() - hdpc_rows.height();
-        for row in row_offset..self.A.height() {
-            for col in col_offset..(col_offset + size) {
-                let value = if row < first_hdpc_row {
-                    self.A.get(row, col)
-                } else {
-                    hdpc_rows.get(row - first_hdpc_row, col)
-                };
-                submatrix.set(row - row_offset, col - col_offset, value);
+        for row in row_offset..first_hdpc_row {
+            let dest_row = row - row_offset;
+            for col in 0..size {
+                // Binary matrix → 0/1 octet; avoid Octet construction in set().
+                submatrix.set_byte(dest_row, col, self.A.get(row, col_offset + col).byte());
             }
+        }
+        for hr in 0..hdpc_rows.height() {
+            let dest_row = first_hdpc_row - row_offset + hr;
+            let src = &hdpc_rows.row_as_slice(hr)[col_offset..(col_offset + size)];
+            submatrix.copy_row_segment(dest_row, 0, src);
         }
 
         for i in 0..size {

--- a/src/symbol_slab.rs
+++ b/src/symbol_slab.rs
@@ -39,6 +39,52 @@ impl SymbolSlab {
         }
     }
 
+    /// Build a slab of `total_symbols` with:
+    /// - `zero_prefix_symbols` leading all-zero symbols,
+    /// - then the contiguous `source` bytes (must be a multiple of `symbol_size`),
+    /// - then zero-filled padding through `total_symbols`.
+    ///
+    /// Unlike [`with_zeros`] + overwrite, the source region is never memzero'd.
+    pub(crate) fn with_zero_prefix_source_and_padding(
+        total_symbols: usize,
+        symbol_size: usize,
+        zero_prefix_symbols: usize,
+        source: &[u8],
+    ) -> Self {
+        assert!(symbol_size > 0, "symbol_size must be non-zero");
+        assert_eq!(
+            source.len() % symbol_size,
+            0,
+            "source length must be a multiple of symbol_size"
+        );
+        let source_symbols = source.len() / symbol_size;
+        assert!(
+            zero_prefix_symbols
+                .checked_add(source_symbols)
+                .is_some_and(|used| used <= total_symbols),
+            "prefix+source exceeds total_symbols"
+        );
+        let total_bytes = total_symbols
+            .checked_mul(symbol_size)
+            .expect("slab byte length overflow");
+        let prefix_bytes = zero_prefix_symbols * symbol_size;
+
+        let mut data = Vec::with_capacity(total_bytes);
+        // Zero only the constraint prefix.
+        data.resize(prefix_bytes, 0);
+        // Copy source without a prior memset of that region.
+        data.extend_from_slice(source);
+        // Zero only the trailing padding (K'..K and any unused tail).
+        data.resize(total_bytes, 0);
+
+        SymbolSlab {
+            data,
+            count: total_symbols,
+            symbol_size,
+            mapping: None,
+        }
+    }
+
     /// Create a slab from already-contiguous symbol bytes.
     pub(crate) fn from_bytes(data: Vec<u8>, symbol_size: usize) -> Self {
         assert!(symbol_size > 0, "symbol_size must be non-zero");
@@ -276,5 +322,19 @@ mod tests {
         slab.fma(0, 1, &scalar);
         // GF(256): 0x01 ^ (0x02 * 3) = 0x01 ^ 0x06 = 0x07
         assert_eq!(slab.get(0), &[0x07]);
+    }
+
+    #[test]
+    fn zero_prefix_source_and_padding_layout() {
+        // 2 zero prefix + 2 source + 1 padding = 5 symbols of size 3
+        let source = vec![1, 2, 3, 4, 5, 6];
+        let slab = SymbolSlab::with_zero_prefix_source_and_padding(5, 3, 2, &source);
+        assert_eq!(slab.len(), 5);
+        assert_eq!(slab.get(0), &[0, 0, 0]);
+        assert_eq!(slab.get(1), &[0, 0, 0]);
+        assert_eq!(slab.get(2), &[1, 2, 3]);
+        assert_eq!(slab.get(3), &[4, 5, 6]);
+        assert_eq!(slab.get(4), &[0, 0, 0]);
+        assert_eq!(slab.as_bytes().len(), 15);
     }
 }


### PR DESCRIPTION
## Summary
Two-commit stack (also split as PR #224 + fork-stacked bulk PR):

1. **create_d selective zeroing** — skip memzero of K·T source region when building intermediate D.
2. **bulk HDPC GE fill** — memcpy HDPC row segments in `record_reduce_to_row_echelon`.

## E2E (Zen5 EPYC 9845, single core)
### vs master baseline (create_d alone)
| cell | baseline | after | delta |
|------|--------:|------:|------:|
| e2e_repair_only K=1000 | 336.8 | 365.5 | +8.5% |
| e2e_repair_only K=5000 | 269.0 | 299.7 | +11.4% |

### bulk on top of create_d (3-run median)
| cell | tip | bulk | delta |
|------|----:|-----:|------:|
| e2e_repair_only K=1000 | 324.6 | 347.6 | +7.1% |
| e2e_source_only K=1000 | 892.6 | 974.4 | +9.2% |

Final stacked tip median e2e_repair@1k ≈ **372 MiB/s**.

## Test plan
- [x] `cargo test --release`
- [x] E2E harness

Prefer reviewing as two commits; #224 is the first commit alone if you want a smaller first merge.