### PR TITLE
new decoder api to improve performances: add non-consuming decode_to writing into a caller buffer

### DIFF
--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -359,13 +359,24 @@ impl SourceBlockDecoder {
         }
 
         if self.received_esi.len() < self.source_block_symbols as usize {
+            // Restore the reset state from function entry instead of leaving `received_esi`/
+            // `received_source_symbols` referencing ESIs this call never stored into
+            // `source_symbols`/`repair_packets`: a caller falling back to the incremental
+            // `decode()` API afterward would otherwise see those ESIs as already received,
+            // take its all-source fast path, and unwrap a `source_symbols` slot that's still
+            // `None`. `clear()` keeps the set's already-allocated capacity, so this doesn't
+            // allocate.
+            self.received_esi.clear();
+            self.received_source_symbols = 0;
             return false;
         }
 
-        out.clear();
-        out.resize(self.symbol_size as usize * self.source_block_symbols as usize, 0);
-
         if self.received_source_symbols == self.source_block_symbols {
+            // Only resize here: this is the one branch that actually writes into `out` in
+            // place. The reconstruction branch below replaces `out` wholesale with its own
+            // freshly built `Vec`, so pre-zeroing it first would just be wasted work.
+            out.clear();
+            out.resize(self.symbol_size as usize * self.source_block_symbols as usize, 0);
             for packet in packets {
                 let esi = packet.payload_id().encoding_symbol_id();
                 if esi < self.source_block_symbols {
@@ -376,6 +387,15 @@ impl SourceBlockDecoder {
             return true;
         }
 
+        // This clones/copies every packet's payload into `self.repair_packets`/
+        // `self.source_symbols`, unlike the fast path above which reads `packets` in place.
+        // That's the cost of `decode_to` only borrowing `packets` (so the caller can keep and
+        // reuse its `Vec<EncodingPacket>` instead of handing over ownership): these two fields
+        // are struct-level state shared with the streaming `decode` API above, which needs
+        // owned data since it accumulates across calls, so this one-shot call pays the same
+        // price even though it alone wouldn't otherwise need to outlive `packets`. Only taken
+        // on the loss path (some source symbol missing), not the common no-loss case.
+        //
         // `self.received_esi` only tells us which ESIs were seen at least once; it doesn't
         // track whether we've already stored a repair packet for one here, so a duplicate
         // repair packet (e.g. received twice) would otherwise be pushed twice, feeding
@@ -992,5 +1012,43 @@ mod codec_tests {
 
         // Verify packets were not consumed
         assert!(!packets.is_empty(), "packets Vec should not be consumed");
+    }
+
+    /// Regression test: a `decode_to` call that fails for lack of packets must not corrupt
+    /// `received_esi`/`received_source_symbols` state used by the incremental `decode()` API.
+    /// Previously, `decode_to` recorded seen ESIs before checking whether it had enough of
+    /// them, so a caller falling back to `decode()` after a failed `decode_to` would find
+    /// those ESIs already marked as received (with no matching `source_symbols` entry),
+    /// letting `decode()` take its all-source fast path and panic on `.unwrap()`.
+    #[test]
+    fn decode_to_insufficient_then_decode_does_not_panic() {
+        let symbol_size = 1280;
+        let symbol_count = 10;
+        let elements = symbol_size * symbol_count as usize;
+        let mut data: Vec<u8> = vec![0; elements];
+        for element in &mut data {
+            *element = rand::rng().random();
+        }
+
+        let config = ObjectTransmissionInformation::new(0, symbol_size as u16, 0, 1, 1);
+        let encoder = SourceBlockEncoder::new(1, &config, &data);
+        let packets = encoder.source_packets();
+
+        let mut decoder = SourceBlockDecoder::new(1, &config, elements as u64);
+
+        // Not enough packets: decode_to must fail without wedging decoder state.
+        let mut decoded = Vec::new();
+        let ok = decoder.decode_to(&packets[..packets.len() - 1], &mut decoded);
+        assert!(!ok, "decode_to should fail when a source packet is missing");
+
+        // Falling back to the incremental API with the full packet set (as a caller would,
+        // re-presenting everything it knows plus what just arrived) must still work rather
+        // than panicking on a `source_symbols` slot the failed decode_to never populated.
+        let result = decoder.decode(packets.iter().cloned());
+        assert!(
+            result.is_some(),
+            "decode() should complete the transfer after a failed decode_to"
+        );
+        assert_eq!(result.unwrap(), data, "decoded data should match the original");
     }
 }

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -330,7 +330,7 @@ impl SourceBlockDecoder {
 
     /// One-shot decode: given the complete, currently-known set of packets for this
     /// source block, reassembles it into `out` (cleared and resized in place) instead
-    /// of returning a freshly allocated `Vec<u8>`, and without consuming `packets` —
+    /// of returning a freshly allocated `Vec<u8>`, and without consuming `packets` --
     /// the caller keeps ownership of its packet buffer.
     ///
     /// In the common case (no source symbol missing) this writes directly from the
@@ -339,7 +339,7 @@ impl SourceBlockDecoder {
     /// cloning the received payloads into owned buffers as needed for that solve.
     ///
     /// Unlike `decode`, this assumes a single call per source block with every
-    /// packet already known — it does not accumulate state across repeated calls.
+    /// packet already known -- it does not accumulate state across repeated calls.
     pub fn decode_to(&mut self, packets: &[EncodingPacket], out: &mut Vec<u8>) -> bool {
         for s in &mut self.source_symbols {
             *s = None;
@@ -390,7 +390,7 @@ impl SourceBlockDecoder {
             // received while `source_symbols` stays all `None`. A caller that falls back to
             // the incremental `decode()` API afterward would then hit its all-source fast
             // path and unwrap a still-`None` slot. Clear the bookkeeping so a later `decode()`
-            // call starts fresh instead of trusting this stale state; `clear()` keeps the
+            // call starts fresh instead of trusting this stale state -- `clear()` keeps the
             // set's capacity, so this doesn't allocate.
             self.received_esi.clear();
             self.received_source_symbols = 0;
@@ -934,7 +934,7 @@ mod codec_tests {
         }
     }
 
-    /// Test decode_to with complete packet set (no loss) — verifies output matches
+    /// Test decode_to with complete packet set (no loss) -- verifies output matches
     /// decode() and packets are not consumed.
     #[test]
     fn decode_to_no_loss() {
@@ -977,7 +977,7 @@ mod codec_tests {
         assert_eq!(packets.len(), symbol_count as usize, "packet count should be unchanged");
     }
 
-    /// Test decode_to with packet loss (needs algebraic reconstruction) — verifies
+    /// Test decode_to with packet loss (needs algebraic reconstruction) -- verifies
     /// output matches decode() with repair packets.
     #[test]
     fn decode_to_with_loss() {

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -308,9 +308,6 @@ impl SourceBlockDecoder {
             }
         }
 
-        let num_extended_symbols = extended_source_block_symbols(self.source_block_symbols);
-        let num_padding_symbols = num_extended_symbols - self.source_block_symbols;
-
         // Case 1: the number of received packets is insufficient for decoding
         if self.received_esi.len() < self.source_block_symbols as usize {
             return None;
@@ -328,7 +325,90 @@ impl SourceBlockDecoder {
             return Some(result);
         }
 
-        // Case 3: we may have sufficient symbols to do a standard decoding
+        self.reconstruct()
+    }
+
+    /// One-shot decode: given the complete, currently-known set of packets for this
+    /// source block, reassembles it into `out` (cleared and resized in place) instead
+    /// of returning a freshly allocated `Vec<u8>`, and without consuming `packets` —
+    /// the caller keeps ownership of its packet buffer.
+    ///
+    /// In the common case (no source symbol missing) this writes directly from the
+    /// borrowed packets into `out` with no `Symbol` allocated. If some source symbols
+    /// are missing, falls back to the same algebraic reconstruction `decode` uses,
+    /// cloning the received payloads into owned buffers as needed for that solve.
+    ///
+    /// Unlike `decode`, this assumes a single call per source block with every
+    /// packet already known — it does not accumulate state across repeated calls.
+    pub fn decode_to(&mut self, packets: &[EncodingPacket], out: &mut Vec<u8>) -> bool {
+        for s in &mut self.source_symbols {
+            *s = None;
+        }
+        self.repair_packets.clear();
+        self.received_source_symbols = 0;
+        self.received_esi.clear();
+        self.decoded = false;
+
+        for packet in packets {
+            assert_eq!(self.source_block_id, packet.payload_id().source_block_number());
+            if self.received_esi.insert(packet.payload_id().encoding_symbol_id())
+                && packet.payload_id().encoding_symbol_id() < self.source_block_symbols
+            {
+                self.received_source_symbols += 1;
+            }
+        }
+
+        if self.received_esi.len() < self.source_block_symbols as usize {
+            return false;
+        }
+
+        out.clear();
+        out.resize(self.symbol_size as usize * self.source_block_symbols as usize, 0);
+
+        if self.received_source_symbols == self.source_block_symbols {
+            for packet in packets {
+                let esi = packet.payload_id().encoding_symbol_id();
+                if esi < self.source_block_symbols {
+                    self.unpack_sub_blocks(out, packet.data(), esi as usize);
+                }
+            }
+            self.decoded = true;
+            return true;
+        }
+
+        // `self.received_esi` only tells us which ESIs were seen at least once; it doesn't
+        // track whether we've already stored a repair packet for one here, so a duplicate
+        // repair packet (e.g. received twice) would otherwise be pushed twice, feeding
+        // `reconstruct()` a redundant equation row and risking a rank-deficient solve.
+        // `source_symbols` doesn't need this: indexed assignment is naturally idempotent.
+        let mut seen_repair_esi = Set::new();
+        for packet in packets {
+            let esi = packet.payload_id().encoding_symbol_id();
+            if esi >= self.source_block_symbols {
+                if seen_repair_esi.insert(esi) {
+                    self.repair_packets.push(packet.clone());
+                }
+            } else {
+                self.source_symbols[esi as usize] = Some(Symbol::new(packet.data().to_vec()));
+            }
+        }
+
+        match self.reconstruct() {
+            Some(result) => {
+                *out = result;
+                true
+            }
+            None => false,
+        }
+    }
+
+    /// Case 3 of `decode`/`decode_to`: not all source symbols were received, so the
+    /// missing ones must be reconstructed algebraically from `self.source_symbols` and
+    /// `self.repair_packets`, which the caller is expected to have already populated.
+    fn reconstruct(&mut self) -> Option<Vec<u8>> {
+        let num_extended_symbols = extended_source_block_symbols(self.source_block_symbols);
+        let num_padding_symbols = num_extended_symbols - self.source_block_symbols;
+
         let s = num_ldpc_symbols(self.source_block_symbols) as usize;
         let h = num_hdpc_symbols(self.source_block_symbols) as usize;
         let l = num_intermediate_symbols(self.source_block_symbols) as usize;
@@ -822,5 +902,95 @@ mod codec_tests {
                 "Decoded data mismatch (repair-only) at symbol_count={symbol_count}"
             );
         }
+    }
+
+    /// Test decode_to with complete packet set (no loss) — verifies output matches
+    /// decode() and packets are not consumed.
+    #[test]
+    fn decode_to_no_loss() {
+        let symbol_size = 1280;
+        let symbol_count = 10;
+        let elements = symbol_size * symbol_count as usize;
+        let mut data: Vec<u8> = vec![0; elements];
+        for element in &mut data {
+            *element = rand::rng().random();
+        }
+
+        let config = ObjectTransmissionInformation::new(0, symbol_size as u16, 0, 1, 1);
+        let encoder = SourceBlockEncoder::new(1, &config, &data);
+
+        // Get all source packets
+        let packets = encoder.source_packets();
+
+        // Decode using original decode() method
+        let mut decoder1 = SourceBlockDecoder::new(1, &config, elements as u64);
+        let mut expected = None;
+        for packet in &packets {
+            expected = decoder1.decode(iter::once(packet.clone()));
+            if expected.is_some() {
+                break;
+            }
+        }
+        let expected = expected.unwrap();
+
+        // Decode using decode_to() method
+        let mut decoder2 = SourceBlockDecoder::new(1, &config, elements as u64);
+        let mut decoded = Vec::new();
+        let ok = decoder2.decode_to(&packets, &mut decoded);
+
+        // Verify decode_to succeeded and output matches
+        assert!(ok, "decode_to should succeed with complete packet set");
+        assert_eq!(decoded, expected, "decode_to output should match decode()");
+
+        // Verify packets were not consumed
+        assert!(!packets.is_empty(), "packets Vec should not be consumed");
+        assert_eq!(packets.len(), symbol_count as usize, "packet count should be unchanged");
+    }
+
+    /// Test decode_to with packet loss (needs algebraic reconstruction) — verifies
+    /// output matches decode() with repair packets.
+    #[test]
+    fn decode_to_with_loss() {
+        let symbol_size = 1280;
+        let symbol_count = 10;
+        let elements = symbol_size * symbol_count as usize;
+        let mut data: Vec<u8> = vec![0; elements];
+        for element in &mut data {
+            *element = rand::rng().random();
+        }
+
+        let config = ObjectTransmissionInformation::new(0, symbol_size as u16, 0, 1, 1);
+        let encoder = SourceBlockEncoder::new(1, &config, &data);
+
+        // Get source and some repair packets, drop one source packet
+        let mut packets = encoder.source_packets();
+        let mut repair_packets = encoder.repair_packets(0, 5);
+        packets.pop(); // Drop last source packet
+
+        // Add repair packets to compensate
+        packets.append(&mut repair_packets);
+
+        // Decode using original decode() method
+        let mut decoder1 = SourceBlockDecoder::new(1, &config, elements as u64);
+        let mut expected = None;
+        for packet in &packets {
+            expected = decoder1.decode(iter::once(packet.clone()));
+            if expected.is_some() {
+                break;
+            }
+        }
+        let expected = expected.expect("should decode with repair packets");
+
+        // Decode using decode_to() method
+        let mut decoder2 = SourceBlockDecoder::new(1, &config, elements as u64);
+        let mut decoded = Vec::new();
+        let ok = decoder2.decode_to(&packets, &mut decoded);
+
+        // Verify decode_to succeeded and output matches
+        assert!(ok, "decode_to should succeed with repair packets");
+        assert_eq!(decoded, expected, "decode_to output should match decode() with repair");
+
+        // Verify packets were not consumed
+        assert!(!packets.is_empty(), "packets Vec should not be consumed");
     }
 }

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -384,6 +384,16 @@ impl SourceBlockDecoder {
                 }
             }
             self.decoded = true;
+            // This fast path writes packet data straight into `out` without storing it into
+            // `self.source_symbols` (that's the point: no `Symbol` allocation). Left as-is,
+            // `received_esi`/`received_source_symbols` would claim every source symbol was
+            // received while `source_symbols` stays all `None`. A caller that falls back to
+            // the incremental `decode()` API afterward would then hit its all-source fast
+            // path and unwrap a still-`None` slot. Clear the bookkeeping so a later `decode()`
+            // call starts fresh instead of trusting this stale state; `clear()` keeps the
+            // set's capacity, so this doesn't allocate.
+            self.received_esi.clear();
+            self.received_source_symbols = 0;
             return true;
         }
 
@@ -1048,6 +1058,42 @@ mod codec_tests {
         assert!(
             result.is_some(),
             "decode() should complete the transfer after a failed decode_to"
+        );
+        assert_eq!(result.unwrap(), data, "decoded data should match the original");
+    }
+
+    /// Regression test: a successful no-loss `decode_to` must not leave `received_esi`/
+    /// `received_source_symbols` claiming every source symbol was received while
+    /// `source_symbols` itself stays unpopulated (that fast path writes straight into `out`
+    /// and never touches `source_symbols`). Otherwise a subsequent `decode()` call on the same
+    /// decoder would take its all-source fast path and panic on `.unwrap()`.
+    #[test]
+    fn decode_to_success_then_decode_does_not_panic() {
+        let symbol_size = 1280;
+        let symbol_count = 10;
+        let elements = symbol_size * symbol_count as usize;
+        let mut data: Vec<u8> = vec![0; elements];
+        for element in &mut data {
+            *element = rand::rng().random();
+        }
+
+        let config = ObjectTransmissionInformation::new(0, symbol_size as u16, 0, 1, 1);
+        let encoder = SourceBlockEncoder::new(1, &config, &data);
+        let packets = encoder.source_packets();
+
+        let mut decoder = SourceBlockDecoder::new(1, &config, elements as u64);
+
+        let mut decoded = Vec::new();
+        let ok = decoder.decode_to(&packets, &mut decoded);
+        assert!(ok, "decode_to should succeed when every source packet is present");
+        assert_eq!(decoded, data, "decode_to output should match the original");
+
+        // Reusing the decoder via the incremental API afterward must not panic, even though
+        // decode_to already reported every ESI as received.
+        let result = decoder.decode(packets.iter().cloned());
+        assert!(
+            result.is_some(),
+            "decode() should still complete after a successful decode_to"
         );
         assert_eq!(result.unwrap(), data, "decoded data should match the original");
     }


### PR DESCRIPTION
SourceBlockDecoder::decode consumes its packets and always allocates a fresh output Vec<u8>, which forces callers that already own their packet buffer to drain it away just to get it back empty for reuse, and to throw away a decoded buffer on every call instead of being able to supply one.

decode_to borrows packets instead (the caller keeps its Vec) and writes into an out: &mut Vec<u8> parameter. In the common case where every source symbol was received it copies straight from the borrowed packets with no Symbol allocated; when reconstruction is needed it falls back to the same algebraic solve as decode (via the newly extracted reconstruct() helper), cloning received payloads into owned buffers only on that rarer path.

Unlike decode, this assumes a single call per source block with every packet already known.